### PR TITLE
[MRG] Include README in index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -3,18 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Scikit-learn enhancement proposals
-==================================
-
-This repository is for structured discussions about large modifications or
-additions to scikit-learn.
-
-The discussions must create an "enhancement proposal", similar Python
-enhancement proposal, that reflects the major arguments to keep in mind, the
-rational and usecases that are addressed, the problems and the major
-possible solution. It should be a summary of the key points that drive the
-decision, and ideally converge to a draft of an API or object to be
-implemented in scikit-learn.
+.. include:: README.rst
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This PR includes README.rst (rendered on github) in `index.rst` (rendered on RTD) to avoid having the same text in 2 different places.

Addresses https://github.com/scikit-learn/enhancement_proposals/pull/10#issuecomment-454516377