### PR TITLE
SLEP009: keyword only arguments

### DIFF
--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -10,7 +10,7 @@ SLEP009: Keyword-only arguments
 :Created: 2019-07-13
 
 Abstract
---------
+########
 
 This proposal discusses the path to gradually forcing users to pass arguments,
 or most of them, as keyword arguments only. It talks about the status-quo, and
@@ -19,7 +19,7 @@ change. The original issue starting the discussion is located
 [here](https://github.com/scikit-learn/scikit-learn/issues/12805).
 
 Motivation
-----------
+##########
 
 At the moment `sklearn` accepts all arguments both as positional and
 keyword arguments. For example, both of the following are valid:
@@ -59,7 +59,7 @@ Using keyword arguments has a few benefits:
   in different sections for the documentation to be more readable.
 
 Solution
---------
+########
 
 The official supported way to have keyword only arguments is:
 
@@ -75,12 +75,38 @@ as keyword arguments:
     func(1, 2, arg3=3, arg4=4)
 
 The feature was discussed and the related PEP
-([PEP3102](https://www.python.org/dev/peps/pep-3102/)) was accepted and
-introduced in Python 3.0, in 2006. However, partly due to the fact that the
-Scipy/PyData was supporting Python 2 until recently, the feature (among other
-Python 3 features) has seen limited adoption and the users may not be used to
-seeing the syntax. For instance, for the above function, defined in VSCode, the
-hint would be shown as (these outputs are without the usage of the decorator):
+`PEP3102 <https://www.python.org/dev/peps/pep-3102/>`_ was accepted and
+introduced in Python 3.0, in 2006.
+
+For the change to happen in ``sklearn``, we would need to add the ``*`` where
+we want all the parameters after which to be passed as keyword only.
+
+Considerations
+##############
+
+We can identify the following main challenges: familiarity of the users with
+the syntax, and its support by different IDEs.
+
+Syntax
+------
+
+Partly due to the fact that the Scipy/PyData has been supporting Python 2 until
+recently, the feature (among other Python 3 features) has seen limited adoption
+and the users may not be used to seeing the syntax.
+
+However, some other teams are already moving towards using the syntax, such as
+``matplotlib`` which has introduced the syntax with a deprecation cycle using a
+decorator for this purpose in version 3.1, and the related PRs can be found
+[here](https://github.com/matplotlib/matplotlib/pull/13601) and
+[here](https://github.com/matplotlib/matplotlib/pull/14130). Soon users will be
+familiar with the syntax.
+
+IDE Support
+-----------
+
+Many users rely on autocomplete and parameter hints of the IDE while coding.
+Here is how the hint looks like in two different IDEs. For instance, for the
+above function, defined in VSCode, the hint would be shown as:
 
 .. code-block:: python
 
@@ -92,7 +118,7 @@ hint would be shown as (these outputs are without the usage of the decorator):
 The good news is that the IDE understands the syntax and tells the user it's
 the ``arg3``'s turn. But it doesn't say it is a keyword only argument.
 
-`ipython` would show:
+`ipython`, however, suggests all parameters be given with the keyword anyway:
 
 .. code-block:: python
 
@@ -105,13 +131,8 @@ the ``arg3``'s turn. But it doesn't say it is a keyword only argument.
       arg1=                          ascii()                         
       arg2=                          AssertionError                  
 
-Challenges
-----------
-
-
-
 Scope
------
+#####
 
 An important open question is which functions/methods and/or parameters should
 follow this pattern, and which parameters should be keyword only. We can
@@ -148,12 +169,13 @@ categories together may be a better option.
 Deprecation Path
 ----------------
 
-A proposed solution is available at
+For a smooth transition, we need an easy deprecation path. Similar to the
+decorators developed in ``matplotlib``, a proposed solution is available at
 [#13311](https://github.com/scikit-learn/scikit-learn/pull/13311), which
-deprecates the usage of positional arguments for most arguments on certain
-functions and methods. It uses a decorator, and removing the decorator would
-result in an error if the function is called with positional arguments.
-Examples (borrowing from the PR):
+deprecates the usage of positional arguments on selected functions and methods.
+With the decorator, the user sees a warning if they pass the designated
+keyword-only arguments as positional, and removing the decorator would result
+in an error. Examples (borrowing from the PR):
 
 .. code-block:: python
 
@@ -182,27 +204,8 @@ Calling ``LogisticRegression('l2', True)`` will result with a
 Once the deprecation period is over, we'd remove the decorator and calling
 the function/method with the positional arguments after `*` would fail.
 
-However, with the decorator, ``ipython`` shows:
-
-.. code-block:: python
-
-    In [2]: func( 
-      arg1=                          ArithmeticError                 
-      abs()                          ascii()                         
-      all()                          AssertionError                 >
-      any()                          AttributeError                  
-
-The parameters are still all there, but a bit more hidden and in a different
-order. The hint shown by VSCode seems unaffected.
-
 Notes
------
+#####
 
 Some conversations with the users of `sklearn` who have been using the package
 for a while, shows the feedback is positive for this change.
-
-It is also worth noting that ``matplotlib`` has introduced a decorator for this
-purpose in versoin 3.1, and the related PRs can be found
-[here](https://github.com/matplotlib/matplotlib/pull/13601) and
-[here](https://github.com/matplotlib/matplotlib/pull/14130).
-

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -24,12 +24,12 @@ Motivation
 At the moment `sklearn` accepts most of the arguments both as positional and
 keyword arguments. For example, both the following are valid:
 
-```python
-# positional arguments
-clf = svm.SVC(.1, 'rbf')
-# keyword arguments
-clf = svm.SVC(C=.1, kernel='rbf')
-```
+.. code-block:: python
+    # positional arguments
+    clf = svm.SVC(.1, 'rbf')
+    # keyword arguments
+    clf = svm.SVC(C=.1, kernel='rbf')
+
 
 Using keyword arguments has a few benefits:
 
@@ -37,16 +37,16 @@ Using keyword arguments has a few benefits:
 - for models which accept many parameters, especially numerical, it is less
   error-prone than positional arguments. Compare these examples:
 
-```python 
-cls = cluster.OPTICS(
-    min_samples=5, max_eps=inf, metric=’minkowski’, p=2,
-    metric_params=None, cluster_method=’xi’, eps=None, xi=0.05,
-    predecessor_correction=True, min_cluster_size=None, algorithm=’auto’,
-    leaf_size=30, n_jobs=None)
+.. code-block:: python
+    cls = cluster.OPTICS(
+        min_samples=5, max_eps=inf, metric=’minkowski’, p=2,
+        metric_params=None, cluster_method=’xi’, eps=None, xi=0.05,
+        predecessor_correction=True, min_cluster_size=None, algorithm=’auto’,
+        leaf_size=30, n_jobs=None)
 
-cls = cluster.OPTICS(5, inf, ’minkowski’, 2, None, ’xi’, None, 0.05,
-                     True, None, ’auto’, 30, None)
-```
+    cls = cluster.OPTICS(5, inf, ’minkowski’, 2, None, ’xi’, None, 0.05,
+                         True, None, ’auto’, 30, None)
+
 
 - it allows us to add new parameters closer the other relevant parameters,
   instead of adding new ones at the end of the list. Right now all new
@@ -64,28 +64,27 @@ functions. It uses a decorator, and removing the decorator would result in an
 error if the function is called with positional arguments. Examples (borrowing
 from the PR):
 
-```python
-@warn_args
-def dbscan(X, eps=0.5, *, min_samples=4, metric='minkowski'):
-    pass
-
-
-class LogisticRegression:
-    
+.. code-block:: python
     @warn_args
-    def __init__(self, penalty='l2', *, dual=False):
+    def dbscan(X, eps=0.5, *, min_samples=4, metric='minkowski'):
+        pass
 
-        self.penalty = penalty
-        self.dual = dual
 
-```
+    class LogisticRegression:
+
+        @warn_args
+        def __init__(self, penalty='l2', *, dual=False):
+
+            self.penalty = penalty
+            self.dual = dual
+
 
 Calling `LogisticRegression('l2', True)` will result with a
 `DeprecationWarning`:
 
-```bash
-Should use keyword args: dual=True
-```
+.. code-block:: bash
+    Should use keyword args: dual=True
+
 
 Once the deprecation period is over, we'd remove the decorator and calling
 the function/method with the positional arguments after `*` would fail.
@@ -95,16 +94,14 @@ Challenges
 
 The official supported way to have keyword only arguments is:
 
-```python
-def func(arg1, arg2, *, arg3, arg4)
-```
+.. code-block:: python
+    def func(arg1, arg2, *, arg3, arg4)
 
 Which means the function can only be called with `arg3` and `arg4` specified
 as keyword arguments:
 
-```python
-func(1, 2, arg3=3, arg4=4)
-```
+.. code-block:: python
+    func(1, 2, arg3=3, arg4=4)
 
 The feature was discussed and the related PEP
 ([PEP3102](https://www.python.org/dev/peps/pep-3102/)) was accepted and
@@ -114,38 +111,35 @@ Python 3 features) has seen limited adoption and the users may not be used to
 seeing the syntax. For instance, for the above function, defined in VSCode,
 the hint would be shown as:
 
-```python
-           func(arg1, arg2, *, arg3, arg4)
+.. code-block:: python
+               func(arg1, arg2, *, arg3, arg4)
 
-           param arg3
-func(1, 2, |)
-```
+               param arg3
+    func(1, 2, |)
 
 The good news is that the IDE understands the syntax and tells the user it's
 the `arg3`'s turn. But it doesn't say it is a keyword only argument.
 
 `ipython` would show:
 
-```python
-In [1]: def func(arg1, arg2, *, arg3, arg4): pass               
+.. code-block:: python
+    In [1]: def func(arg1, arg2, *, arg3, arg4): pass               
 
-In [2]: func( 
-  abs()                          arg3=                           
-  all()                          arg4=                           
-  any()                          ArithmeticError                >
-  arg1=                          ascii()                         
-  arg2=                          AssertionError                  
-```
+    In [2]: func( 
+      abs()                          arg3=                           
+      all()                          arg4=                           
+      any()                          ArithmeticError                >
+      arg1=                          ascii()                         
+      arg2=                          AssertionError                  
 
 However, with the decorator, `ipython` shows:
 
-```python
-In [2]: func( 
-  a=                             ArithmeticError                 
-  abs()                          ascii()                         
-  all()                          AssertionError                 >
-  any()                          AttributeError                  
-```
+.. code-block:: python
+    In [2]: func( 
+      a=                             ArithmeticError                 
+      abs()                          ascii()                         
+      all()                          AssertionError                 >
+      any()                          AttributeError                  
 
 The parameters are still all there, but a bit more hidden and in a different
 order. The hint shown by VSCode seems unaffected.

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -16,7 +16,7 @@ This proposal discusses the path to gradually forcing users to pass arguments,
 or most of them, as keyword arguments only. It talks about the status-quo, and
 the motivation to introduce the change. It shall cover the pros and cons of the
 change. The original issue starting the discussion is located
-[here](https://github.com/scikit-learn/scikit-learn/issues/12805).
+`here <https://github.com/scikit-learn/scikit-learn/issues/12805>`_.
 
 Motivation
 ##########
@@ -108,9 +108,9 @@ following two definitions may also be confusing to some users:
 
 However, some other teams are already moving towards using the syntax, such as
 ``matplotlib`` which has introduced the syntax with a deprecation cycle using a
-decorator for this purpose in version 3.1. The related PRs can be found
-[here](https://github.com/matplotlib/matplotlib/pull/13601) and
-[here](https://github.com/matplotlib/matplotlib/pull/14130). Soon users will be
+decorator for this purpose in version 3.1. The related PRs can be found `here
+<https://github.com/matplotlib/matplotlib/pull/13601>`_ and `here
+<https://github.com/matplotlib/matplotlib/pull/14130>`_. Soon users will be
 familiar with the syntax.
 
 IDE Support
@@ -148,35 +148,32 @@ Scope
 
 An important open question is which functions/methods and/or parameters should
 follow this pattern, and which parameters should be keyword only. We can
-identify the following categories and the corresponding options we have for
-each of them:
+identify the following categories of functions/methods:
 
-- The ``__init__`` parameters
-  * All arguments
-  * Less commonly used arguments only (For instance, ``C`` and ``kernel`` in
-  ``SVC`` could be positional, the rest keyword only).
+- ``__init__``s
 - Main methods of the API, *i.e.* ``fit``, ``transform``, etc.
-  * All arguments
-  * Less commonly used arguments only (For instance, ``X`` and ``y`` in
-  ``fit`` could be positional, the rest keyword only).
 - All other methods, *e.g.* ``SpectralBiclustering.get_submatrix``
-  * All arguments (and this being the only option since these methods are more
-  ad-hoc).
 - Functions
-  * All arguments
-  * Less commonly used arguments only (For instance, ``score_func`` in
-  ``make_scorer`` could be positional, the rest keyword only).
 
-The term *commonly used* here can either refer to the parameters which are used
-across the library, such as ``X`` and ``y``, or a parameter which is often used
-when that method is used, such as ``C`` for ``SVC``. In the spirit of having a
-similar interface across the library, we can go with the first definition, and
-define the positional parameters independent of the estimator/function.
+With regard to the common methods of the API, the decision for these methods
+should be the same throughout the library in order to keep a consistent
+interface to the user.
 
-The change can also be a gradual one in the span of two or three releases,
-*i.e.* we can start by changing the ``__init__``s, and continue later with the
-other ones. But that may cause more confusion, and changing all the above
-categories together may be a better option.
+This proposal suggests making only *most commonly* used parameters positional.
+The *most commonly* used parameters are defined per method or function, to be
+defined as either of the following two ways:
+
+- The set defined and agreed upon by the core developers, which should cover
+  the *easy* cases.
+- A set identified as being in the top 95% of the use cases, using some
+  automated analysis such as `this one
+  <https://odyssey.readthedocs.io/en/latest/tutorial.html>`_ or `this one
+  <https://github.com/Quansight-Labs/python-api-inspect>`_.
+
+This way we would minimize the number of warnings the users would receive,
+which minimizes the friction cause by the change. This SLEP does not define
+these parameter sets, and the respective decisions shall be made in their
+corresponding pull requests.
 
 Deprecation Path
 ----------------
@@ -215,3 +212,7 @@ Calling ``LogisticRegression('l2', True)`` will result with a
 
 Once the deprecation period is over, we'd remove the decorator and calling
 the function/method with the positional arguments after `*` would fail.
+
+The final decorator solution shall make sure it is well understood by most
+commonly used IDEs and editors such as IPython, Jupiter Lab, Emacs, vim,
+VSCode, and PyCharm.

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -149,3 +149,9 @@ In [2]: func(
 
 The parameters are still all there, but a bit more hidden and in a different
 order. The hint shown by VSCode seems unaffected.
+
+Notes
+-----
+
+Some conversations with the users of `sklearn` who have been using the package
+for a while, shows the feedback is positive for this change.

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -1,0 +1,151 @@
+.. _slep_009:
+
+===============================
+SLEP009: Keyword-only arguments
+===============================
+
+:Author: Adrin Jalali
+:Status: Draft
+:Type: Standards Track
+:Created: 2019-07-13
+
+Abstract
+--------
+
+This proposal discusses the path to gradually forcing users to pass arguments,
+or most of them, as keyword arguments only. It talks about the status-quo, and
+the motivation to introduce the change. It shall cover the pros and cons of the
+change. The original issue starting the discussion is located
+[here](https://github.com/scikit-learn/scikit-learn/issues/12805).
+
+Motivation
+----------
+
+At the moment `sklearn` accepts most of the arguments both as positional and
+keyword arguments. For example, both the following are valid:
+
+```python
+# positional arguments
+clf = svm.SVC(.1, 'rbf')
+# keyword arguments
+clf = svm.SVC(C=.1, kernel='rbf')
+```
+
+Using keyword arguments has a few benefits:
+
+- it is more readable
+- for models which accept many parameters, especially numerical, it is less
+  error-prone than positional arguments. Compare these examples:
+
+```python 
+cls = cluster.OPTICS(
+    min_samples=5, max_eps=inf, metric=’minkowski’, p=2,
+    metric_params=None, cluster_method=’xi’, eps=None, xi=0.05,
+    predecessor_correction=True, min_cluster_size=None, algorithm=’auto’,
+    leaf_size=30, n_jobs=None)
+
+cls = cluster.OPTICS(5, inf, ’minkowski’, 2, None, ’xi’, None, 0.05,
+                     True, None, ’auto’, 30, None)
+```
+
+- it allows us to add new parameters closer the other relevant parameters,
+  instead of adding new ones at the end of the list. Right now all new
+  parameters are added at the end for backward compatibility. We may even get
+  some sections support in numpydoc, and have sections in the documentation for
+  the parameters.
+
+Solution
+--------
+
+A proposed solution is available at
+[#13311](https://github.com/scikit-learn/scikit-learn/pull/13311), which
+deprecates the usage of positional arguments for most arguments on certain
+functions. It uses a decorator, and removing the decorator would result in an
+error if the function is called with positional arguments. Examples (borrowing
+from the PR):
+
+```python
+@warn_args
+def dbscan(X, eps=0.5, *, min_samples=4, metric='minkowski'):
+    pass
+
+
+class LogisticRegression:
+    
+    @warn_args
+    def __init__(self, penalty='l2', *, dual=False):
+
+        self.penalty = penalty
+        self.dual = dual
+
+```
+
+Calling `LogisticRegression('l2', True)` will result with a
+`DeprecationWarning`:
+
+```bash
+Should use keyword args: dual=True
+```
+
+Once the deprecation period is over, we'd remove the decorator and calling
+the function/method with the positional arguments after `*` would fail.
+
+Challenges
+----------
+
+The official supported way to have keyword only arguments is:
+
+```python
+def func(arg1, arg2, *, arg3, arg4)
+```
+
+Which means the function can only be called with `arg3` and `arg4` specified
+as keyword arguments:
+
+```python
+func(1, 2, arg3=3, arg4=4)
+```
+
+The feature was discussed and the related PEP
+([PEP3102](https://www.python.org/dev/peps/pep-3102/)) was accepted and
+introduced in Python 3.0, in 2006. However, partly due to the fact that the
+Scipy/PyData was supporting Python 2 until recently, the feature (among other
+Python 3 features) has seen limited adoption and the users may not be used to
+seeing the syntax. For instance, for the above function, defined in VSCode,
+the hint would be shown as:
+
+```python
+           func(arg1, arg2, *, arg3, arg4)
+
+           param arg3
+func(1, 2, |)
+```
+
+The good news is that the IDE understands the syntax and tells the user it's
+the `arg3`'s turn. But it doesn't say it is a keyword only argument.
+
+`ipython` would show:
+
+```python
+In [1]: def func(arg1, arg2, *, arg3, arg4): pass               
+
+In [2]: func( 
+  abs()                          arg3=                           
+  all()                          arg4=                           
+  any()                          ArithmeticError                >
+  arg1=                          ascii()                         
+  arg2=                          AssertionError                  
+```
+
+However, with the decorator, `ipython` shows:
+
+```
+In [2]: func( 
+  a=                             ArithmeticError                 
+  abs()                          ascii()                         
+  all()                          AssertionError                 >
+  any()                          AttributeError                  
+```
+
+The parameters are still all there, but a bit more hidden and in a different
+order. The hint shown by VSCode seems unaffected.

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -160,16 +160,16 @@ The main question is, which functions/methods should follow this pattern. We
 have a few categories here:
 
 - The ``__init__`` parameters
-  - all arguments
-  - less commonly used arguments only (For instance, ``C`` and ``kernel`` in
+  * all arguments
+  * less commonly used arguments only (For instance, ``C`` and ``kernel`` in
     ``SVC`` could be positional, the rest keyword only).
 - Main methods of the API, _i.e._ ``fit``, ``transform``, etc.
-  - all arguments
-  - less commonly used arguments only (For instance, ``X`` and ``y`` in
+  * all arguments
+  * less commonly used arguments only (For instance, ``X`` and ``y`` in
     ``fit`` could be positional, the rest keyword only).
 - Functions
-  - all arguments
-  - less commonly used arguments only (For instance, ``score_func`` in
+  * all arguments
+  * less commonly used arguments only (For instance, ``score_func`` in
     ``make_scorer`` could be positional, the rest keyword only).
 
 The change can also be a gradual one in the span of two or three releases. But

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -25,6 +25,7 @@ At the moment `sklearn` accepts most of the arguments both as positional and
 keyword arguments. For example, both the following are valid:
 
 .. code-block:: python
+
     # positional arguments
     clf = svm.SVC(.1, 'rbf')
     # keyword arguments
@@ -38,6 +39,7 @@ Using keyword arguments has a few benefits:
   error-prone than positional arguments. Compare these examples:
 
 .. code-block:: python
+
     cls = cluster.OPTICS(
         min_samples=5, max_eps=inf, metric=’minkowski’, p=2,
         metric_params=None, cluster_method=’xi’, eps=None, xi=0.05,
@@ -65,6 +67,7 @@ error if the function is called with positional arguments. Examples (borrowing
 from the PR):
 
 .. code-block:: python
+
     @warn_args
     def dbscan(X, eps=0.5, *, min_samples=4, metric='minkowski'):
         pass
@@ -83,6 +86,7 @@ Calling `LogisticRegression('l2', True)` will result with a
 `DeprecationWarning`:
 
 .. code-block:: bash
+
     Should use keyword args: dual=True
 
 
@@ -95,12 +99,14 @@ Challenges
 The official supported way to have keyword only arguments is:
 
 .. code-block:: python
+
     def func(arg1, arg2, *, arg3, arg4)
 
 Which means the function can only be called with `arg3` and `arg4` specified
 as keyword arguments:
 
 .. code-block:: python
+
     func(1, 2, arg3=3, arg4=4)
 
 The feature was discussed and the related PEP
@@ -112,6 +118,7 @@ seeing the syntax. For instance, for the above function, defined in VSCode,
 the hint would be shown as:
 
 .. code-block:: python
+
                func(arg1, arg2, *, arg3, arg4)
 
                param arg3
@@ -123,6 +130,7 @@ the `arg3`'s turn. But it doesn't say it is a keyword only argument.
 `ipython` would show:
 
 .. code-block:: python
+
     In [1]: def func(arg1, arg2, *, arg3, arg4): pass               
 
     In [2]: func( 
@@ -135,6 +143,7 @@ the `arg3`'s turn. But it doesn't say it is a keyword only argument.
 However, with the decorator, `ipython` shows:
 
 .. code-block:: python
+
     In [2]: func( 
       a=                             ArithmeticError                 
       abs()                          ascii()                         

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -139,7 +139,7 @@ In [2]: func(
 
 However, with the decorator, `ipython` shows:
 
-```
+```python
 In [2]: func( 
   a=                             ArithmeticError                 
   abs()                          ascii()                         

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -82,8 +82,8 @@ from the PR):
             self.dual = dual
 
 
-Calling `LogisticRegression('l2', True)` will result with a
-`DeprecationWarning`:
+Calling ``LogisticRegression('l2', True)`` will result with a
+``DeprecationWarning``:
 
 .. code-block:: bash
 
@@ -114,8 +114,8 @@ The feature was discussed and the related PEP
 introduced in Python 3.0, in 2006. However, partly due to the fact that the
 Scipy/PyData was supporting Python 2 until recently, the feature (among other
 Python 3 features) has seen limited adoption and the users may not be used to
-seeing the syntax. For instance, for the above function, defined in VSCode,
-the hint would be shown as:
+seeing the syntax. For instance, for the above function, defined in VSCode, the
+hint would be shown as (these outputs are without the usage of the decorator):
 
 .. code-block:: python
 
@@ -125,7 +125,7 @@ the hint would be shown as:
     func(1, 2, |)
 
 The good news is that the IDE understands the syntax and tells the user it's
-the `arg3`'s turn. But it doesn't say it is a keyword only argument.
+the ``arg3``'s turn. But it doesn't say it is a keyword only argument.
 
 `ipython` would show:
 
@@ -140,12 +140,12 @@ the `arg3`'s turn. But it doesn't say it is a keyword only argument.
       arg1=                          ascii()                         
       arg2=                          AssertionError                  
 
-However, with the decorator, `ipython` shows:
+However, with the decorator, ``ipython`` shows:
 
 .. code-block:: python
 
     In [2]: func( 
-      a=                             ArithmeticError                 
+      arg1=                          ArithmeticError                 
       abs()                          ascii()                         
       all()                          AssertionError                 >
       any()                          AttributeError                  
@@ -153,8 +153,37 @@ However, with the decorator, `ipython` shows:
 The parameters are still all there, but a bit more hidden and in a different
 order. The hint shown by VSCode seems unaffected.
 
+Scope
+-----
+
+The main question is, which functions/methods should follow this pattern. We
+have a few categories here:
+
+- The ``__init__`` parameters
+  - all arguments
+  - less commonly used arguments only (For instance, ``C`` and ``kernel`` in
+    ``SVC`` could be positional, the rest keyword only).
+- Main methods of the API, _i.e._ ``fit``, ``transform``, etc.
+  - all arguments
+  - less commonly used arguments only (For instance, ``X`` and ``y`` in
+    ``fit`` could be positional, the rest keyword only).
+- Functions
+  - all arguments
+  - less commonly used arguments only (For instance, ``score_func`` in
+    ``make_scorer`` could be positional, the rest keyword only).
+
+The change can also be a gradual one in the span of two or three releases. But
+I'm not sure if that's a better idea than telling people they should do keyword
+only, always, once.
+
 Notes
 -----
 
 Some conversations with the users of `sklearn` who have been using the package
 for a while, shows the feedback is positive for this change.
+
+It is also worth noting that ``matplotlib`` has introduced a decorator for this
+purpose in versoin 3.1, and the related PRs can be found
+[here](https://github.com/matplotlib/matplotlib/pull/14130) and
+[here](https://github.com/matplotlib/matplotlib/pull/14130).
+

--- a/slep009/proposal.rst
+++ b/slep009/proposal.rst
@@ -50,13 +50,18 @@ Using keyword arguments has a few benefits:
                          True, None, ’auto’, 30, None)
 
 
-- It allows adding new parameters closer the other relevant parameters,
-  instead of adding new ones at the end of the list without breaking backward
+- It allows adding new parameters closer the other relevant parameters, instead
+  of adding new ones at the end of the list without breaking backward
   compatibility. Right now all new parameters are added at the end of the
   signature. Once we move to a keyword only argument list, we can change their
   order and put related parameters together. Assuming at some point numpydoc
-  would support sections for parameters, these groups of parameters would be
-  in different sections for the documentation to be more readable.
+  would support sections for parameters, these groups of parameters would be in
+  different sections for the documentation to be more readable. Also, note that
+  we have previously assumed users would pass most parameters by name and have
+  sometimes considered changes to be backwards compatible when they modified
+  the order of parameters. For example, user code relying on positional
+  arguments could break after a deprecated parameter was removed. Accepting
+  this SLEP would make this requirement explicit.
 
 Solution
 ########
@@ -79,7 +84,7 @@ The feature was discussed and the related PEP
 introduced in Python 3.0, in 2006.
 
 For the change to happen in ``sklearn``, we would need to add the ``*`` where
-we want all the parameters after which to be passed as keyword only.
+we want all subsequent parameters to be passed as keyword only.
 
 Considerations
 ##############
@@ -92,11 +97,18 @@ Syntax
 
 Partly due to the fact that the Scipy/PyData has been supporting Python 2 until
 recently, the feature (among other Python 3 features) has seen limited adoption
-and the users may not be used to seeing the syntax.
+and the users may not be used to seeing the syntax. The similarity between the
+following two definitions may also be confusing to some users:
+
+.. code-block:: python
+
+    def f(arg1, *arg2, arg3): pass # variable length arguments at arg2 
+
+    def f(arg1, *, arg3): pass # no arguments accepted at *
 
 However, some other teams are already moving towards using the syntax, such as
 ``matplotlib`` which has introduced the syntax with a deprecation cycle using a
-decorator for this purpose in version 3.1, and the related PRs can be found
+decorator for this purpose in version 3.1. The related PRs can be found
 [here](https://github.com/matplotlib/matplotlib/pull/13601) and
 [here](https://github.com/matplotlib/matplotlib/pull/14130). Soon users will be
 familiar with the syntax.
@@ -203,9 +215,3 @@ Calling ``LogisticRegression('l2', True)`` will result with a
 
 Once the deprecation period is over, we'd remove the decorator and calling
 the function/method with the positional arguments after `*` would fail.
-
-Notes
-#####
-
-Some conversations with the users of `sklearn` who have been using the package
-for a while, shows the feedback is positive for this change.


### PR DESCRIPTION
This is to formalize our discussion around introducing keyword only arguments.

It follows https://github.com/scikit-learn/scikit-learn/issues/12805 and https://github.com/scikit-learn/scikit-learn/pull/13311

It should be an easy one, since the solution is already there, and it seems more like a matter of making a decision.

@scikit-learn/core-devs 