### PR TITLE
Removed .config.yml, because it is not needed for this project

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate


### PR DESCRIPTION
`theme: jekyll-theme-slate`, isn't needed because you are using a readthedocs.io