### PR TITLE
VOTE: SLEP006 - Metadata Routing

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -9,6 +9,7 @@
     :maxdepth: 1
     :caption: Accepted
 
+    slep006/proposal
     slep007/proposal
     slep009/proposal
     slep010/proposal
@@ -17,7 +18,6 @@
     :maxdepth: 1
     :caption: Under review
 
-    slep006/proposal
     slep012/proposal
     slep013/proposal
 

--- a/slep006/proposal.rst
+++ b/slep006/proposal.rst
@@ -56,13 +56,13 @@ This SLEP proposes to add
 
 * `get_metadata_routing` to all **consumers** and **routers**
   (i.e. all estimators, scorers, and splitters supporting this API)
-* `*_requests` to consumers (including estimators, scorers, and CV splitters),
-  where `*` is a method that requires metadata. (e.g. `fit_requests`,
-  `score_requests`, `transform_requests`, etc.)
+* `set_*_request` to consumers (including estimators, scorers, and CV
+  splitters), where `*` is a method that requires metadata. (e.g.
+  `set_fit_request`, `set_score_request`, `set_transform_request`, etc.)
 
-For example, `fit_requests` configures an estimator to request metadata::
+For example, `set_fit_request` configures an estimator to request metadata::
 
-    >>> log_reg = LogisticRegression().fit_requests(sample_weight=True)
+    >>> log_reg = LogisticRegression().set_fit_request(sample_weight=True)
 
 `get_metadata_routing` are used by **routers** to inspect the metadata needed
 by **consumers**. `get_metadata_routing` returns a `MetadataRouter` or a
@@ -92,7 +92,7 @@ requests `groups` by default::
 
     >>> weighted_acc = make_scorer(accuracy_score).score_request(sample_weight=True)
     >>> log_reg = (LogisticRegressionCV(cv=GroupKFold(), scoring=weighted_acc)
-    ...           .fit_requests(sample_weight=True))
+    ...           .set_fit_request(sample_weight=True))
     >>> cv_results = cross_validate(
     ...     log_reg, X, y,
     ...     cv=GroupKFold(),
@@ -117,7 +117,7 @@ Unweighted Feature selection
 will _not_ be routed weights::
 
     >>> log_reg = (LogisticRegressionCV(cv=GroupKFold(), scoring=weighted_acc)
-    ...            .fit_requests(sample_weight=True))
+    ...            .set_fit_request(sample_weight=True))
     >>> sel = SelectKBest(k=2)
     >>> pipe = make_pipeline(sel, log_reg)
     >>> pipe.fit(X, y, sample_weight=weights, groups=groups)
@@ -135,9 +135,9 @@ this example, `scoring_weight` is passed to the scoring and `fitting_weight`
 is passed to `LogisticRegressionCV`::
 
     >>> weighted_acc = (make_scorer(accuracy_score)
-    ...                 .score_requests(sample_weight="scoring_weight"))
+    ...                 .set_score_request(sample_weight="scoring_weight"))
     >>> log_reg = (LogisticRegressionCV(cv=GroupKFold(), scoring=weighted_acc)
-    ...            .fit_requests(sample_weight="fitting_weight"))
+    ...            .set_fit_request(sample_weight="fitting_weight"))
     >>> cv_results = cross_validate(
     ...     log_reg, X, y,
     ...     cv=GroupKFold(),
@@ -171,7 +171,7 @@ This SLEP has a draft implementation at :pr:`22083` by :user:`adrinjalali`. The
 implementation provides developer utilities that are used by scikit-learn and
 available to third-party estimators for adopting this SLEP. Specifically, the
 draft implementation makes it easier to define `get_metadata_routing` and
-`*_requests` for **consumers** and **routers**.
+`set_*_request` for **consumers** and **routers**.
 
 Backward compatibility
 ----------------------
@@ -191,7 +191,9 @@ a deprecation warning is raised::
 To avoid the warning, one would need to specify the request in
 `LogisticRegression`::
 
-    >>> grid = GridSearchCV(LogisticRegression().fit_requests(sample_weight=True), ...)
+    >>> grid = GridSearchCV(
+    ...     LogisticRegression().set_fit_request(sample_weight=True), ...
+    ... )
     >>> grid.fit(X, y, sample_weight=sw)
 
 Meta-estimators such as `GridSearchCV` will check which metadata is requested,
@@ -208,15 +210,15 @@ not configured to request it::
     >>> grid.fit(X, y, sample_weight=sw)
 
 To avoid the error, `LogisticRegression` must specify its metadata request by
-calling `fit_requests`::
+calling `set_fit_request`::
 
     >>> # Request sample weights
-    >>> log_reg_weights = LogisticRegression().fit_requests(sample_weight=True)
+    >>> log_reg_weights = LogisticRegression().set_fit_request(sample_weight=True)
     >>> grid = GridSearchCV(log_reg_with_weights, ...)
     >>> grid.fit(X, y, sample_weight=sw)
     >>>
     >>> # Do not request sample_weights
-    >>> log_reg_no_weights = LogisticRegression().fit_requests(sample_weight=False)
+    >>> log_reg_no_weights = LogisticRegression().set_fit_request(sample_weight=False)
     >>> grid = GridSearchCV(log_reg_no_weights, ...)
     >>> grid.fit(X, y, sample_weight=sw)
 

--- a/slep006/proposal.rst
+++ b/slep006/proposal.rst
@@ -69,6 +69,9 @@ by **consumers**. `get_metadata_routing` returns a `MetadataRouter` or a
 `MetadataRequest` object that stores and handles metadata routing. See the
 draft implementation for more implementation details.
 
+Note that in the core library nothing is requested by default, except
+``groups`` in ``Group*CV`` objects which request the ``groups`` metadata.
+
 Detailed description
 --------------------
 
@@ -200,8 +203,8 @@ not configured to request it::
     >>> # `grid.fit`.
     >>> grid.fit(X, y, sample_weight=sw)
 
-To avoid the error, `LogisticRegression` must specify its metadata request by calling
-`fit_requests`::
+To avoid the error, `LogisticRegression` must specify its metadata request by
+calling `fit_requests`::
 
     >>> # Request sample weights
     >>> log_reg_weights = LogisticRegression().fit_requests(sample_weight=True)
@@ -213,10 +216,13 @@ To avoid the error, `LogisticRegression` must specify its metadata request by ca
     >>> grid = GridSearchCV(log_reg_no_weights, ...)
     >>> grid.fit(X, , sample_weight=sw)
 
-Third-party estimators will need to adopt this SLEP in order to support metadata
-routing, while the dunder syntax is deprecated. Our implementation will provide
-developer APIs to trigger warnings and errors as described above to help with
-adopting this SLEP.
+Note that a meta-estimator will raise an error if the user passes a metadata
+which is not requested by any of the child objects of the meta-estimator.
+
+Third-party estimators will need to adopt this SLEP in order to support
+metadata routing, while the dunder syntax is deprecated. Our implementation
+will provide developer APIs to trigger warnings and errors as described above
+to help with adopting this SLEP.
 
 Alternatives
 ------------

--- a/slep006/proposal.rst
+++ b/slep006/proposal.rst
@@ -89,7 +89,7 @@ requests `groups` by default::
     >>> cv_results = cross_validate(
     ...     log_reg, X, y,
     ...     cv=GroupKFold(),
-    ...     props={"sample_weight": my_weights, "groups": my_groups},
+    ...     metadata={"sample_weight": my_weights, "groups": my_groups},
     ...     scoring=weighted_acc)
 
 To support unweighted fitting and weighted scoring, metadata is set to `False`
@@ -100,7 +100,7 @@ in `request_for_fit`::
     >>> cross_validate(
     ...     log_reg, X, y,
     ...     cv=GroupKFold(),
-    ...     props={'sample_weight': weights, 'groups': groups},
+    ...     metadata={'sample_weight': weights, 'groups': groups},
     ...     scoring=weighted_acc)
 
 Unweighted Feature selection
@@ -134,7 +134,7 @@ is passed to `LogisticRegressionCV`::
     >>> cv_results = cross_validate(
     ...     log_reg, X, y,
     ...     cv=GroupKFold(),
-    ...     props={"scoring_weight": my_weights,
+    ...     metadata={"scoring_weight": my_weights,
     ...            "fitting_weight": my_other_weights,
     ...            "groups": my_groups},
     ...     scoring=weighted_acc)
@@ -155,7 +155,7 @@ and the inner random search::
     >>> cv_results = cross_validate(
     ...     log_reg, X, y,
     ...     cv=GroupKFold(),
-    ...     props={"groups": my_groups})
+    ...     metadata={"groups": my_groups})
 
 Implementation
 --------------

--- a/slep006/proposal.rst
+++ b/slep006/proposal.rst
@@ -5,7 +5,7 @@ SLEP006: Metadata Routing
 =========================
 
 :Author: Joel Nothman, Adrin Jalali, Alex Gramfort, Thomas J. Fan
-:Status: Under Review
+:Status: Accepted
 :Type: Standards Track
 :Created: 2019-03-07
 

--- a/slep006/proposal.rst
+++ b/slep006/proposal.rst
@@ -66,11 +66,15 @@ For example, `fit_requests` configures an estimator to request metadata::
 
 `get_metadata_routing` are used by **routers** to inspect the metadata needed
 by **consumers**. `get_metadata_routing` returns a `MetadataRouter` or a
-`MetadataRequest` object that stores and handles metadata routing. See the
-draft implementation for more implementation details.
+`MetadataRequest` object that stores and handles metadata routing.
+`get_metadata_routing` returns enough information for a router to know what
+metadata is requested, and whether the metadata is sample aligned or not. See
+the draft implementation for more implementation details.
 
 Note that in the core library nothing is requested by default, except
-``groups`` in ``Group*CV`` objects which request the ``groups`` metadata.
+``groups`` in ``Group*CV`` objects which request the ``groups`` metadata. At
+the time of writing this proposal, all metadata requested in the core library
+are sample aligned.
 
 Detailed description
 --------------------


### PR DESCRIPTION
This PR is for us to discuss and collect votes for SLEP006 - Metadata Routing (was sample props).

A rendered version of the SLEP is available [here](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep006/proposal.html), and detailed past discussions can be found under [these PRs](https://github.com/scikit-learn/enhancement_proposals/pulls?q=is%3Apr++slep006+) and [these issues](https://github.com/scikit-learn/enhancement_proposals/issues?q=is%3Aissue+slep006).

The current proposed implementation is drafted under https://github.com/scikit-learn/scikit-learn/pull/22083 where you can find a rendered version of the user guide [here](https://174636-843222-gh.circle-artifacts.com/0/doc/metadata_routing.html) and a rendered version of the developer API (only applicable to third party developers and people who write custom estimators) [here](https://174636-843222-gh.circle-artifacts.com/0/doc/auto_examples/plot_metadata_routing.html). These are found under `metadata_routing.rst` and `plot_metadata_routing.py` under the aforementioned [PR](https://github.com/scikit-learn/scikit-learn/pull/22083) respectively. Note that this PR does NOT touch scorers, splitters, or any of the estimators or meta-estimators in scikit-learn. It implements the machinery in `BaseEstimator` for _consumers_ only. The PR is also not targeted to `main`, and instead it's to be merged into the `sample-props` branch on the main repo, with follow-up PRs to complete the implementation before merging into `main`.

Please leave your votes  here, and comment here, on the mailing list, or open new PRs/issues in this repo or the main repo for specifics if you think further discussion is required.

Note that this vote is not to merge the implementation PR, and is rather to accept the SLEP, and the SLEP does NOT discuss implementation details and the API for us and third party developers; but we're more than happy to discuss the implementation and the API during this voting round.

We also plan to send out a survey asking third party developers for their opinion of our proposed developer API, parallel to this call for vote.

This vote will close on February 21, 2022.