### PR TITLE
SLEP006: correct terminology use

### DIFF
--- a/slep006/proposal.rst
+++ b/slep006/proposal.rst
@@ -142,9 +142,9 @@ is passed to `LogisticRegressionCV`::
 Nested Grouped Cross Validation with SearchCV
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since `GroupKFold` requests group metadata by default, `GroupKFold` can be
-passed to multiple **consumers** to enable nested grouped cross validation. In
-this example, both `RandomizedSearchCV` and `cross_validate` sets
+Since `GroupKFold` requests group metadata by default, `GroupKFold` instances can
+be passed to multiple **routers** to enable nested grouped cross validation. In
+this example, both `RandomizedSearchCV` and `cross_validate` set
 `cv=GroupKFold()` which enables grouped CV in the outer loop (`cross_validate`)
 and the inner random search::
 


### PR DESCRIPTION
Here GroupKFold is the consumer. It knows what `groups` means. The things that provide it with `groups` do not know what `groups` means, only that `GroupKFold` requests it. Hence they are routers.