### PR TITLE
SLEP018 Pandas output for transformers with set_output

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -21,6 +21,7 @@
 
     slep012/proposal
     slep013/proposal
+    slep018/proposal
 
 .. toctree::
     :maxdepth: 1

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -50,8 +50,12 @@ in the pipeline::
    X_trans_df = num_preprocessor[0].transform(X_df)
 
 Meta-estimators that support ``set_output`` are required to configure all inner
-transformer by calling ``set_output``. If an inner transformer does not define
-``set_output``, then an error is raised.
+transformer by calling ``set_output``. Specifically all fitted and non-fitted
+inner transformers must be configured with ``set_output``. This enables
+``transform``'s output to be a DataFrame before and after the meta-estimator is
+fitted. If an inner transformer does not define ``set_output``, then an error is
+raised.
+
 
 Global Configuration
 ....................

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -22,7 +22,7 @@ Currently, scikit-learn transformers return NumPy ndarrays or SciPy sparse matri
 This SLEP proposes adding a ``set_output`` method to configure a transformer to output
 pandas DataFrames::
 
-   scalar = StandardScalar().set_output(transform="pandas_or_namedsparse")
+   scalar = StandardScalar().set_output(transform="pandas")
    scalar.fit(X_df)
 
    # X_trans_df is a pandas DataFrame
@@ -32,7 +32,7 @@ For a pipeline, calling ``set_output`` on the pipeline will configure
 all steps in the pipeline::
 
    num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
-   num_preprocessor.set_output(transform="pandas_or_namedsparse")
+   num_preprocessor.set_output(transform="pandas")
 
    # X_trans_df is a pandas DataFrame
    X_trans_df = num_preprocessor.fit_transform(X_df)
@@ -44,31 +44,10 @@ pandas DataFrame::
       SimpleImputer(),
       DependsOnPandasInputStandardScalar(),  # Depends on Pandas input to train
    )
-   num_prep.set_output(transform="pandas_or_namedsparse")
+   num_prep.set_output(transform="pandas")
 
    # Pipeline calls ``SimpleImputer.fit_transform`` returning a pandas DataFrame
    num_prep.fit(X_df)
-
-Sparse Data
-...........
-
-The Pandas DataFrame is not suitable to provide column names because it has
-performance issues as shown in
-`#16772 <https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
-This SLEP proposes a scikit-learn specific sparse container that subclasses SciPy's
-sparse matrices. This sparse container includes the sparse data, feature names and
-index. This enables pipelines with Vectorizers without performance issues::
-
-   pipe = make_pipeline(
-      CountVectorizer(),
-      TfidfTransformer(),
-      LogisticRegression(solver="liblinear")
-   )
-
-   pipe.set_output(transform="pandas_or_namedsparse")
-
-   # feature names for logistic regression
-   pipe[-1].feature_names_in_
 
 Global Configuration
 ....................
@@ -77,7 +56,7 @@ This SLEP proposes a global configuration flag that sets the output for
 all transformers::
 
    import sklearn
-   sklearn.set_config(transform_output="pandas_or_namedsparse")
+   sklearn.set_config(transform_output="pandas")
 
 The global default configuration is ``"default"`` where the estimator determines
 the output container.
@@ -122,6 +101,30 @@ A list of issues discussing Pandas output are:
 `#14315 <https://github.com/scikit-learn/scikit-learn/pull/14315>`__,
 `#20100 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and
 `#23001 <https://github.com/scikit-learn/scikit-learn/issueas/23001>`__.
+
+Future Extensions
+-----------------
+
+Sparse Data
+...........
+
+The Pandas DataFrame is not suitable to provide column names because it has
+performance issues as shown in
+`#16772 <https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
+A possible future extension to this SLEP is to have a ``"pandas_or_namedsparse"``
+option. This option will use a scikit-learn specific sparse container that subclasses SciPy's
+sparse matrices. This sparse container includes the sparse data, feature names and
+index. This enables pipelines with Vectorizers without performance issues::
+
+   pipe = make_pipeline(
+      CountVectorizer(),
+      TfidfTransformer(),
+      LogisticRegression(solver="liblinear")
+   )
+   pipe.set_output(transform="pandas_or_namedsparse")
+
+   # feature names for logistic regression
+   pipe[-1].feature_names_in_
 
 References and Footnotes
 ------------------------

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -28,8 +28,10 @@ pandas DataFrames::
    # X_trans_df is a pandas DataFrame
    X_trans_df = scalar.transform(X_df)
 
-For a pipeline, calling ``set_output`` on the pipeline will configure
-all steps in the pipeline::
+The index of the output DataFrame must match the index of the input.
+
+For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the
+pipeline::
 
    num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
    num_preprocessor.set_output(transform="pandas")
@@ -37,17 +39,8 @@ all steps in the pipeline::
    # X_trans_df is a pandas DataFrame
    X_trans_df = num_preprocessor.fit_transform(X_df)
 
-By setting ``transform="pandas"`` calls to ``fit_transform`` will also return a
-pandas DataFrame::
-
-   num_prep = make_pipeline(
-      SimpleImputer(),
-      DependsOnPandasInputStandardScalar(),  # Depends on Pandas input to train
-   )
-   num_prep.set_output(transform="pandas")
-
-   # Pipeline calls ``SimpleImputer.fit_transform`` returning a pandas DataFrame
-   num_prep.fit(X_df)
+Meta-estimators that support ``set_output`` are required to configure all estimators
+by calling ``set_output``.
 
 Global Configuration
 ....................
@@ -76,8 +69,9 @@ Backward compatibility
 
 There are no backward compatibility concerns, because the ``set_output`` method
 is a new API. Third party estimators can opt-in to the API by defining
-``set_output``. The scikit-learn sparse container is backward compatible because
-it is a subclass of SciPy's sparse matrix.
+``set_output``. Meta-estimators that define ``set_output`` to configure
+it's inner estimators with ``set_output`` should error if any of the inner
+estimators do not define ``set_output``.
 
 Alternatives
 ------------

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -12,7 +12,7 @@ SLEP018: Pandas Output for Transformers with set_output
 Abstract
 --------
 
-This SLEP proposes a ``set_output`` method to configure the output container of
+This SLEP proposes a ``set_output`` method to configure the output data container of
 scikit-learn transformers.
 
 Detailed description
@@ -32,9 +32,10 @@ The index of the output DataFrame must match the index of the input. If the
 transformer does not support ``transform="pandas"``, then it must raise a
 ``ValueError`` stating that it does not support the feature.
 
-For this SLEP, ``set_output`` will only configure the output for dense data.  If
-the transformer returns sparse data, then ``transform`` will raise a
-``ValueError`` if ``set_output(transform="pandas")``.
+This SLEP's only focus is dense data for ``set_output``. If a transformer returns
+sparse data, e.g. `OneHotEncoder(sparse=True), then ``transform`` will raise a
+``ValueError`` if ``set_output(transform="pandas")``. Dealing with sparse output
+might be the scope of another future SLEP.
 
 For a pipeline, calling ``set_output`` on the pipeline will configure all steps
 in the pipeline::
@@ -44,6 +45,9 @@ in the pipeline::
 
    # X_trans_df is a pandas DataFrame
    X_trans_df = num_preprocessor.fit_transform(X_df)
+   
+   # X_trans_df is again a pandas DataFrame
+   X_trans_df = num_preprocessor[0].transform(X_df)
 
 Meta-estimators that support ``set_output`` are required to configure all inner
 transformer by calling ``set_output``. If an inner transformer does not define
@@ -52,7 +56,7 @@ transformer by calling ``set_output``. If an inner transformer does not define
 Global Configuration
 ....................
 
-This SLEP proposes a global configuration flag that sets the output for all
+For ease of use, this SLEP proposes a global configuration flag that sets the output for all
 transformers::
 
    import sklearn
@@ -64,7 +68,7 @@ determines the output container.
 Implementation
 --------------
 
-The implementation of this SLEP is in :pr:`23734`.
+A possible implementation of this SLEP is worked out in :pr:`23734`.
 
 Backward compatibility
 ----------------------
@@ -99,7 +103,7 @@ A list of issues discussing Pandas output are: `#14315
 
 Future Extensions
 -----------------
-
+For information only!
 Sparse Data
 ...........
 

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -1,0 +1,139 @@
+.. _slep_018:
+
+=======================================================
+SLEP018: Pandas Output for Transformers with set_output
+=======================================================
+
+:Author: Thomas J. Fan
+:Status: Draft
+:Type: Standards Track
+:Created: 2022-05-23
+
+Abstract
+--------
+
+This SLEP proposes a ``set_output`` method to configure the output container of
+scikit-learn transformers.
+
+Detailed description
+--------------------
+
+Currently, scikit-learn transformers return NumPy ndarrays or SciPy sparse matrices.
+This SLEP proposes adding a ``set_output`` method to configure a transformer to output
+pandas DataFrames::
+
+   scalar = StandardScalar().set_output(transform="pandas_or_namedsparse")
+   scalar.fit(X_df)
+
+   # X_trans_df is a pandas DataFrame
+   X_trans_df = scalar.transform(X_df)
+
+For a pipeline, calling ``set_output`` on the pipeline will configure
+all steps in the pipeline::
+
+   num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
+   num_preprocessor.set_output(transform="pandas_or_namedsparse")
+
+   # X_trans_df is a pandas DataFrame
+   X_trans_df = num_preprocessor.fit_transform(X_df)
+
+By setting ``transform="pandas"`` calls to ``fit_transform`` will also return a
+pandas DataFrame::
+
+   num_prep = make_pipeline(
+      SimpleImputer(),
+      DependsOnPandasInputStandardScalar(),  # Depends on Pandas input to train
+   )
+   num_prep.set_output(transform="pandas_or_namedsparse")
+
+   # Pipeline calls ``SimpleImputer.fit_transform`` returning a pandas DataFrame
+   num_prep.fit(X_df)
+
+Sparse Data
+...........
+
+The Pandas DataFrame is not suitable to provide column names because it has
+performance issues as shown in
+`#16772 <https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
+This SLEP proposes a scikit-learn specific sparse container that subclasses SciPy's
+sparse matrices. This sparse container includes the sparse data, feature names and
+index. This enables pipelines with Vectorizers without performance issues::
+
+   pipe = make_pipeline(
+      CountVectorizer(),
+      TfidfTransformer(),
+      LogisticRegression(solver="liblinear")
+   )
+
+   pipe.set_output(transform="pandas_or_namedsparse")
+
+   # feature names for logistic regression
+   pipe[-1].feature_names_in_
+
+Global Configuration
+....................
+
+This SLEP proposes a global configuration flag that sets the output for
+all transformers::
+
+   import sklearn
+   sklearn.set_config(transform_output="pandas_or_namedsparse")
+
+The global default configuration is ``"default"`` where the estimator determines
+the output container.
+
+Implementation
+--------------
+
+A prototype implementation was created to showcase different use cases for this SLEP,
+which is seen in
+`this rendered notebook <https://nbviewer.org/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__
+and
+`this interactive notebook <https://colab.research.google.com/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__.
+
+
+Backward compatibility
+----------------------
+
+There are no backward compatibility concerns, because the ``set_output`` method
+is a new API. Third party estimators can opt-in to the API by defining
+``set_output``. The scikit-learn sparse container is backward compatible because
+it is a subclass of SciPy's sparse matrix.
+
+Alternatives
+------------
+
+Alternatives to this SLEP includes:
+
+1. `SLEP014 <https://github.com/scikit-learn/enhancement_proposals/pull/37>`__
+   proposes that if the input is a DataFrame than the output is a DataFrame.
+2. :ref:`SLEP012 <slep_012>` proposes a custom scikit-learn container
+   for dense and sparse data that contains feature names. This SLEP
+   also proposes a custom container for sparse data, but pandas for dense data.
+3. Prototype `#20100 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__
+   showcases ``array_out="pandas"`` in `transform`. This API
+   is limited because does not directly support fitting on a pipeline where the
+   steps requires data frames input.
+
+Discussion
+----------
+
+A list of issues discussing Pandas output are:
+`#14315 <https://github.com/scikit-learn/scikit-learn/pull/14315>`__,
+`#20100 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and
+`#23001 <https://github.com/scikit-learn/scikit-learn/issueas/23001>`__.
+
+References and Footnotes
+------------------------
+
+.. [1] Each SLEP must either be explicitly labeled as placed in the public
+   domain (see this SLEP as an example) or licensed under the `Open
+   Publication License`_.
+
+.. _Open Publication License: https://www.opencontent.org/openpub/
+
+
+Copyright
+---------
+
+This document has been placed in the public domain. [1]_

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -31,7 +31,7 @@ pandas DataFrames::
 The index of the output DataFrame must match the index of the input. For this
 SLEP, ``set_output`` will only configure the output for dense data. If a
 transformer returns sparse data, then ``transform`` will error if ``set_output``
-is to "pandas". If a transformer always returns sparse data, then calling
+is set to "pandas". If a transformer always returns sparse data, then calling
 `set_output="pandas"` may raise an error.
 
 For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -65,6 +65,21 @@ transformers::
 The global default configuration is ``"default"`` where the transformer
 determines the output container.
 
+The configuration can also be set locally using the ``config_context`` context
+manager:
+
+   from sklearn import config_context
+   with config_context(transform_output="pandas"):
+      num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
+      num_preprocessor.fit_transform(X_df)
+
+The following specifies the precedence levels for the three ways to configure
+the output container:
+
+1. Locally configure a transformer: ``transformer.set_output``
+2. Context manager: ``config_context``
+3. Global configuration: ``set_config``
+
 Implementation
 --------------
 
@@ -84,10 +99,7 @@ Alternatives to this SLEP includes:
 
 1. `SLEP014 <https://github.com/scikit-learn/enhancement_proposals/pull/37>`__
    proposes that if the input is a DataFrame than the output is a DataFrame.
-2. :ref:`SLEP012 <slep_012>` proposes a custom scikit-learn container for dense
-   and sparse data that contains feature names. This SLEP also proposes a custom
-   container for sparse data, but pandas for dense data.
-3. Prototype `#20100
+2. Prototype `#20100
    <https://github.com/scikit-learn/scikit-learn/pull/20100>`__ showcases
    ``array_out="pandas"`` in `transform`. This API is limited because does not
    directly support fitting on a pipeline where the steps requires data frames
@@ -107,8 +119,8 @@ For information only!
 Sparse Data
 ...........
 
-The Pandas DataFrame is not suitable to provide column names because it has
-performance issues as shown in `#16772
+The Pandas DataFrame is not suitable to provide column names for sparse data
+because it has performance issues as shown in `#16772
 <https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
 A future extension to this SLEP is to have a ``"pandas_or_namedsparse"`` option.
 This option will use a scikit-learn specific sparse container that subclasses

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -31,7 +31,8 @@ pandas DataFrames::
 The index of the output DataFrame must match the index of the input. For this
 SLEP, ``set_output`` will only configure the output for dense data. If a
 transformer returns sparse data, then ``transform`` will error if ``set_output``
-is to "pandas".
+is to "pandas". If a transformer always returns sparse data, then calling
+`set_output="pandas"` may raise an error.
 
 For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the
 pipeline::

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -7,7 +7,7 @@ SLEP018: Pandas Output for Transformers with set_output
 :Author: Thomas J. Fan
 :Status: Draft
 :Type: Standards Track
-:Created: 2022-05-23
+:Created: 2022-06-22
 
 Abstract
 --------
@@ -18,9 +18,9 @@ scikit-learn transformers.
 Detailed description
 --------------------
 
-Currently, scikit-learn transformers return NumPy ndarrays or SciPy sparse matrices.
-This SLEP proposes adding a ``set_output`` method to configure a transformer to output
-pandas DataFrames::
+Currently, scikit-learn transformers return NumPy ndarrays or SciPy sparse
+matrices. This SLEP proposes adding a ``set_output`` method to configure a
+transformer to output pandas DataFrames::
 
    scalar = StandardScalar().set_output(transform="pandas")
    scalar.fit(X_df)
@@ -28,14 +28,16 @@ pandas DataFrames::
    # X_trans_df is a pandas DataFrame
    X_trans_df = scalar.transform(X_df)
 
-The index of the output DataFrame must match the index of the input. For this
-SLEP, ``set_output`` will only configure the output for dense data. If a
-transformer returns sparse data, then ``transform`` will error if ``set_output``
-is set to "pandas". If a transformer always returns sparse data, then calling
-`set_output="pandas"` may raise an error.
+The index of the output DataFrame must match the index of the input. If the
+transformer does not support ``transform="pandas"``, then it must raise a
+``ValueError`` stating that it does not support the feature.
 
-For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the
-pipeline::
+For this SLEP, ``set_output`` will only configure the output for dense data.  If
+the transformer returns sparse data, then ``transform`` will raise a
+``ValueError`` if ``set_output(transform="pandas")``.
+
+For a pipeline, calling ``set_output`` on the pipeline will configure all steps
+in the pipeline::
 
    num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
    num_preprocessor.set_output(transform="pandas")
@@ -43,39 +45,38 @@ pipeline::
    # X_trans_df is a pandas DataFrame
    X_trans_df = num_preprocessor.fit_transform(X_df)
 
-Meta-estimators that support ``set_output`` are required to configure all estimators
-by calling ``set_output``.
+Meta-estimators that support ``set_output`` are required to configure all inner
+transformer by calling ``set_output``. If an inner transformer does not define
+``set_output``, then an error is raised.
 
 Global Configuration
 ....................
 
-This SLEP proposes a global configuration flag that sets the output for
-all transformers::
+This SLEP proposes a global configuration flag that sets the output for all
+transformers::
 
    import sklearn
    sklearn.set_config(transform_output="pandas")
 
-The global default configuration is ``"default"`` where the estimator determines
-the output container.
+The global default configuration is ``"default"`` where the transformer
+determines the output container.
 
 Implementation
 --------------
 
-A prototype implementation was created to showcase different use cases for this SLEP,
-which is seen in
-`this rendered notebook <https://nbviewer.org/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__
-and
-`this interactive notebook <https://colab.research.google.com/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__.
+A prototype implementation was created to showcase different use cases for this
+SLEP, which is seen in `this rendered notebook
+<https://nbviewer.org/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__
+and `this interactive notebook
+<https://colab.research.google.com/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__.
 
 
 Backward compatibility
 ----------------------
 
 There are no backward compatibility concerns, because the ``set_output`` method
-is a new API. Third party estimators can opt-in to the API by defining
-``set_output``. Meta-estimators that define ``set_output`` to configure
-it's inner estimators with ``set_output`` should error if any of the inner
-estimators do not define ``set_output``.
+is a new API. Third party transformers can opt-in to the API by defining
+``set_output``.
 
 Alternatives
 ------------
@@ -84,21 +85,22 @@ Alternatives to this SLEP includes:
 
 1. `SLEP014 <https://github.com/scikit-learn/enhancement_proposals/pull/37>`__
    proposes that if the input is a DataFrame than the output is a DataFrame.
-2. :ref:`SLEP012 <slep_012>` proposes a custom scikit-learn container
-   for dense and sparse data that contains feature names. This SLEP
-   also proposes a custom container for sparse data, but pandas for dense data.
-3. Prototype `#20100 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__
-   showcases ``array_out="pandas"`` in `transform`. This API
-   is limited because does not directly support fitting on a pipeline where the
-   steps requires data frames input.
+2. :ref:`SLEP012 <slep_012>` proposes a custom scikit-learn container for dense
+   and sparse data that contains feature names. This SLEP also proposes a custom
+   container for sparse data, but pandas for dense data.
+3. Prototype `#20100
+   <https://github.com/scikit-learn/scikit-learn/pull/20100>`__ showcases
+   ``array_out="pandas"`` in `transform`. This API is limited because does not
+   directly support fitting on a pipeline where the steps requires data frames
+   input.
 
 Discussion
 ----------
 
-A list of issues discussing Pandas output are:
-`#14315 <https://github.com/scikit-learn/scikit-learn/pull/14315>`__,
-`#20100 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and
-`#23001 <https://github.com/scikit-learn/scikit-learn/issueas/23001>`__.
+A list of issues discussing Pandas output are: `#14315
+<https://github.com/scikit-learn/scikit-learn/pull/14315>`__, `#20100
+<https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and `#23001
+<https://github.com/scikit-learn/scikit-learn/issueas/23001>`__.
 
 Future Extensions
 -----------------
@@ -107,12 +109,13 @@ Sparse Data
 ...........
 
 The Pandas DataFrame is not suitable to provide column names because it has
-performance issues as shown in
-`#16772 <https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
+performance issues as shown in `#16772
+<https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
 A future extension to this SLEP is to have a ``"pandas_or_namedsparse"`` option.
-This option will use a scikit-learn specific sparse container that subclasses SciPy's
-sparse matrices. This sparse container includes the sparse data, feature names and
-index. This enables pipelines with Vectorizers without performance issues::
+This option will use a scikit-learn specific sparse container that subclasses
+SciPy's sparse matrices. This sparse container includes the sparse data, feature
+names and index. This enables pipelines with Vectorizers without performance
+issues::
 
    pipe = make_pipeline(
       CountVectorizer(),
@@ -128,8 +131,8 @@ References and Footnotes
 ------------------------
 
 .. [1] Each SLEP must either be explicitly labeled as placed in the public
-   domain (see this SLEP as an example) or licensed under the `Open
-   Publication License`_.
+   domain (see this SLEP as an example) or licensed under the `Open Publication
+   License`_.
 
 .. _Open Publication License: https://www.opencontent.org/openpub/
 

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -28,7 +28,9 @@ pandas DataFrames::
    # X_trans_df is a pandas DataFrame
    X_trans_df = scalar.transform(X_df)
 
-The index of the output DataFrame must match the index of the input.
+The index of the output DataFrame must match the index of the input. For this SLEP,
+``set_output`` will only configure the output for dense output. If an transformer
+returns sparse data, ``set_output`` will not influence the output container.
 
 For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the
 pipeline::
@@ -105,8 +107,8 @@ Sparse Data
 The Pandas DataFrame is not suitable to provide column names because it has
 performance issues as shown in
 `#16772 <https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
-A possible future extension to this SLEP is to have a ``"pandas_or_namedsparse"``
-option. This option will use a scikit-learn specific sparse container that subclasses SciPy's
+A future extension to this SLEP is to have a ``"pandas_or_namedsparse"`` option.
+This option will use a scikit-learn specific sparse container that subclasses SciPy's
 sparse matrices. This sparse container includes the sparse data, feature names and
 index. This enables pipelines with Vectorizers without performance issues::
 

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -64,12 +64,7 @@ determines the output container.
 Implementation
 --------------
 
-A prototype implementation was created to showcase different use cases for this
-SLEP, which is seen in `this rendered notebook
-<https://nbviewer.org/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__
-and `this interactive notebook
-<https://colab.research.google.com/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb>`__.
-
+The implementation of this SLEP is in :pr:`23734`.
 
 Backward compatibility
 ----------------------

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -28,9 +28,10 @@ pandas DataFrames::
    # X_trans_df is a pandas DataFrame
    X_trans_df = scalar.transform(X_df)
 
-The index of the output DataFrame must match the index of the input. For this SLEP,
-``set_output`` will only configure the container for dense output. If an transformer
-returns sparse data, ``set_output`` will not influence the output container.
+The index of the output DataFrame must match the index of the input. For this
+SLEP, ``set_output`` will only configure the output for dense data. If a
+transformer returns sparse data, then ``transform`` will error if ``set_output``
+is to "pandas".
 
 For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the
 pipeline::

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -115,8 +115,10 @@ Discussion
 A list of issues discussing Pandas output are: `#14315
 <https://github.com/scikit-learn/scikit-learn/pull/14315>`__, `#20100
 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and `#23001
-<https://github.com/scikit-learn/scikit-learn/issueas/23001>`__.
-
+<https://github.com/scikit-learn/scikit-learn/issueas/23001>`__. This SLEP
+proposes configuring the output to be pandas because it is the DataFrame library
+that is most widely used and requested by users. The ``set_output`` can be
+extended to support support additional DataFrame libraries in the future.
 
 References and Footnotes
 ------------------------

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -29,7 +29,7 @@ pandas DataFrames::
    X_trans_df = scalar.transform(X_df)
 
 The index of the output DataFrame must match the index of the input. For this SLEP,
-``set_output`` will only configure the output for dense output. If an transformer
+``set_output`` will only configure the container for dense output. If an transformer
 returns sparse data, ``set_output`` will not influence the output container.
 
 For a pipeline, calling ``set_output`` on the pipeline will configure all steps in the

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -45,7 +45,7 @@ in the pipeline::
 
    # X_trans_df is a pandas DataFrame
    X_trans_df = num_preprocessor.fit_transform(X_df)
-   
+
    # X_trans_df is again a pandas DataFrame
    X_trans_df = num_preprocessor[0].transform(X_df)
 
@@ -113,30 +113,6 @@ A list of issues discussing Pandas output are: `#14315
 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and `#23001
 <https://github.com/scikit-learn/scikit-learn/issueas/23001>`__.
 
-Future Extensions
------------------
-For information only!
-Sparse Data
-...........
-
-The Pandas DataFrame is not suitable to provide column names for sparse data
-because it has performance issues as shown in `#16772
-<https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-615423097>`__.
-A future extension to this SLEP is to have a ``"pandas_or_namedsparse"`` option.
-This option will use a scikit-learn specific sparse container that subclasses
-SciPy's sparse matrices. This sparse container includes the sparse data, feature
-names and index. This enables pipelines with Vectorizers without performance
-issues::
-
-   pipe = make_pipeline(
-      CountVectorizer(),
-      TfidfTransformer(),
-      LogisticRegression(solver="liblinear")
-   )
-   pipe.set_output(transform="pandas_or_namedsparse")
-
-   # feature names for logistic regression
-   pipe[-1].feature_names_in_
 
 References and Footnotes
 ------------------------


### PR DESCRIPTION
This SLEP proposes a `set_output` API used to configure the output of `transform`. The overall idea is to use `set_output(transform="pandas_or_sparse")`, which outputs a pandas dataframe for dense data and a scipy sparse matrix for sparse data.

### Use cases

I put together a functional prototype of this API that you can explore in [this colab notebook](https://colab.research.google.com/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb). Here is a [rendered version of the demo](https://nbviewer.org/github/thomasjpfan/pandas-prototype-demo/blob/main/index.ipynb). The demo includes the following use cases:

- DataFrame output from a Single transformer
- Column Transformer with DataFrame output
- Feature selection based on column names with cross validation
- Using HistGradientBoosting to select categories based on dtype
- Text preprocessing with sparse data

#### Future Extensions

The Pandas DataFrame is not suitable to provide column names for sparse data because it has performance issues as shown in [#16772](https://github.com/scikit-learn/scikit-learn/pull/16772#issuecomment-61542309). A future extension to this SLEP is to have a ``"pandas_or_namedsparse"`` option. This option will use a scikit-learn specific sparse container that subclasses SciPy's sparse matrices. This sparse container includes the sparse data, feature names and index. This enables pipelines with Vectorizers without performance issues::

```
pipe = make_pipeline(
   CountVectorizer(),
   TfidfTransformer(),
   LogisticRegression(solver="liblinear")
)
pipe.set_output(transform="pandas_or_namedsparse")

# feature names for logistic regression
pipe[-1].feature_names_in_
```

CC @amueller @glemaitre @lorentzenchr 