### PR TITLE
VOTE SLEP018 - Pandas Output for Transformers

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,6 +14,7 @@
     slep007/proposal
     slep009/proposal
     slep010/proposal
+    slep018/proposal
 
 .. toctree::
     :maxdepth: 1
@@ -21,7 +22,6 @@
 
     slep012/proposal
     slep013/proposal
-    slep018/proposal
 
 .. toctree::
     :maxdepth: 1

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -39,7 +39,7 @@ might be the scope of another future SLEP.
 
 For a pipeline, calling ``set_output`` will configure all inner transformers::
 
-   num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
+   num_preprocessor = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
    num_preprocessor.set_output(transform="pandas")
 
    # X_trans_df is a pandas DataFrame

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -37,8 +37,7 @@ sparse data, e.g. `OneHotEncoder(sparse=True), then ``transform`` will raise a
 ``ValueError`` if ``set_output(transform="pandas")``. Dealing with sparse output
 might be the scope of another future SLEP.
 
-For a pipeline, calling ``set_output`` on the pipeline will configure all steps
-in the pipeline::
+For a pipeline, calling ``set_output`` will configure all inner transformers::
 
    num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
    num_preprocessor.set_output(transform="pandas")

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -56,7 +56,7 @@ does not configure non-transformers. This enables the following workflow::
    log_reg[-1].feature_names_in_
 
 Meta-estimators that support ``set_output`` are required to configure all inner
-transformer by calling ``set_output``. Specifically all fitted and non-fitted
+transformers by calling ``set_output``. Specifically all fitted and non-fitted
 inner transformers must be configured with ``set_output``. This enables
 ``transform``'s output to be a DataFrame before and after the meta-estimator is
 fitted. If an inner transformer does not define ``set_output``, then an error is

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -48,6 +48,18 @@ For a pipeline, calling ``set_output`` will configure all inner transformers::
    # X_trans_df is again a pandas DataFrame
    X_trans_df = num_preprocessor[0].transform(X_df)
 
+``set_output`` on a pipeline only configures transformers and does not configure
+non-transformers. This enables the following workflow::
+
+   log_reg = make_pipeline(SimpleImputer(), StandardScalar(), LogisticRegression())
+   log_reg.set_output(transform="pandas")
+
+   # All transformers return DataFrames during fit
+   log_reg.fit(X_f, y)
+
+   # The final step contains the feature names in
+   log_reg[-1].feature_names_in_
+
 Meta-estimators that support ``set_output`` are required to configure all inner
 transformer by calling ``set_output``. Specifically all fitted and non-fitted
 inner transformers must be configured with ``set_output``. This enables

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -39,25 +39,19 @@ might be the scope of another future SLEP.
 
 For a pipeline, calling ``set_output`` will configure all inner transformers::
 
-   num_preprocessor = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
-   num_preprocessor.set_output(transform="pandas")
-
-   # X_trans_df is a pandas DataFrame
-   X_trans_df = num_preprocessor.fit_transform(X_df)
-
-   # X_trans_df is again a pandas DataFrame
-   X_trans_df = num_preprocessor[0].transform(X_df)
-
-``set_output`` on a pipeline only configures transformers and does not configure
-non-transformers. This enables the following workflow::
-
    log_reg = make_pipeline(SimpleImputer(), StandardScalar(), LogisticRegression())
    log_reg.set_output(transform="pandas")
 
    # All transformers return DataFrames during fit
-   log_reg.fit(X_f, y)
+   log_reg.fit(X_df, y)
 
-   # The final step contains the feature names in
+   # X_trans_df is a pandas DataFrame
+   X_trans_df = log_reg[:-1].transform(X_df)
+
+   # X_trans_df is again a pandas DataFrame
+   X_trans_df = log_reg[0].transform(X_df)
+
+   # The classifier contains the feature names in
    log_reg[-1].feature_names_in_
 
 Meta-estimators that support ``set_output`` are required to configure all inner

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -123,8 +123,9 @@ A list of issues discussing Pandas output are: `#14315
 <https://github.com/scikit-learn/scikit-learn/pull/20100>`__, and `#23001
 <https://github.com/scikit-learn/scikit-learn/issueas/23001>`__. This SLEP
 proposes configuring the output to be pandas because it is the DataFrame library
-that is most widely used and requested by users. The ``set_output`` can be
-extended to support support additional DataFrame libraries in the future.
+that is most widely used and requested by users. The ``set_output`` API can be
+extended to support additional DataFrame libraries and sparse data formats in
+the future.
 
 References and Footnotes
 ------------------------

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -5,7 +5,7 @@ SLEP018: Pandas Output for Transformers with set_output
 =======================================================
 
 :Author: Thomas J. Fan
-:Status: Draft
+:Status: Accepted
 :Type: Standards Track
 :Created: 2022-06-22
 

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -22,7 +22,7 @@ Currently, scikit-learn transformers return NumPy ndarrays or SciPy sparse
 matrices. This SLEP proposes adding a ``set_output`` method to configure a
 transformer to output pandas DataFrames::
 
-   scalar = StandardScalar().set_output(transform="pandas")
+   scalar = StandardScaler().set_output(transform="pandas")
    scalar.fit(X_df)
 
    # X_trans_df is a pandas DataFrame
@@ -40,7 +40,7 @@ might be the scope of another future SLEP.
 For a pipeline, calling ``set_output`` will configure all inner transformers and
 does not configure non-transformers. This enables the following workflow::
 
-   log_reg = make_pipeline(SimpleImputer(), StandardScalar(), LogisticRegression())
+   log_reg = make_pipeline(SimpleImputer(), StandardScaler(), LogisticRegression())
    log_reg.set_output(transform="pandas")
 
    # All transformers return DataFrames during fit
@@ -80,7 +80,7 @@ manager::
 
    from sklearn import config_context
    with config_context(transform_output="pandas"):
-      num_prep = make_pipeline(SimpleImputer(), StandardScalar(), PCA())
+      num_prep = make_pipeline(SimpleImputer(), StandardScaler(), PCA())
       num_preprocessor.fit_transform(X_df)
 
 The following specifies the precedence levels for the three ways to configure

--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -37,7 +37,8 @@ sparse data, e.g. `OneHotEncoder(sparse=True), then ``transform`` will raise a
 ``ValueError`` if ``set_output(transform="pandas")``. Dealing with sparse output
 might be the scope of another future SLEP.
 
-For a pipeline, calling ``set_output`` will configure all inner transformers::
+For a pipeline, calling ``set_output`` will configure all inner transformers and
+does not configure non-transformers. This enables the following workflow::
 
    log_reg = make_pipeline(SimpleImputer(), StandardScalar(), LogisticRegression())
    log_reg.set_output(transform="pandas")


### PR DESCRIPTION
This PR is for us to discuss and collect votes for [SLEP018 - Pandas Output for Transformers](https://scikit-learn-enhancement-proposals--72.org.readthedocs.build/en/72/slep018/proposal.html). The current implementation is available at https://github.com/scikit-learn/scikit-learn/pull/23734. Note that this vote is for the API and the implementation can be adjusted.

According to our [governance model](https://scikit-learn.org/stable/governance.html#decision-making-process), the vote will be open for a month (till 17th August), and the motion is accepted if 2/3 of the cast votes are in favor.

@scikit-learn/core-devs 