### PR TITLE
DOC Rename 'default' to 'native' for set_output SLEP

### DIFF
--- a/slep018/proposal.rst
+++ b/slep018/proposal.rst
@@ -72,7 +72,7 @@ transformers::
    import sklearn
    sklearn.set_config(transform_output="pandas")
 
-The global default configuration is ``"default"`` where the transformer
+The global default configuration is ``"native"`` where the transformer
 determines the output container.
 
 The configuration can also be set locally using the ``config_context`` context


### PR DESCRIPTION
Based on the discussion in https://github.com/scikit-learn/scikit-learn/pull/23734#pullrequestreview-1135967664, reviewers concluded that "default" was not descriptive enough. The PR was updated to use `"native"` instead.