### PR TITLE
slep019: Add non-core-dev contributors to an ack section

### DIFF
--- a/slep019/proposal.rst
+++ b/slep019/proposal.rst
@@ -144,7 +144,7 @@ will replace a vote on the private Core Contributors' mailing list.
 Acknowledgment
 **************
 
-We talk the following people who have helped with discussions during the
+We thank the following people who have helped with discussions during the
 development of this SLEP:
 
 - Lucy Liu: https://github.com/lucyleeow

--- a/slep019/proposal.rst
+++ b/slep019/proposal.rst
@@ -139,6 +139,18 @@ In this case, the vote still has to be announced on the Core
 Contributors' mailing list, but the system of Pull Request approvals
 will replace a vote on the private Core Contributors' mailing list.
 
+
+**************
+Acknowledgment
+**************
+
+We talk the following people who have helped with discussions during the
+development of this SLEP:
+
+- Lucy Liu: https://github.com/lucyleeow
+- Noa Tamir: https://github.com/noatamir
+- Reshama Shaikh: https://github.com/reshamas
+
 ***********
  Copyright
 ***********

--- a/slep019/proposal.rst
+++ b/slep019/proposal.rst
@@ -150,6 +150,7 @@ development of this SLEP:
 - Lucy Liu: https://github.com/lucyleeow
 - Noa Tamir: https://github.com/noatamir
 - Reshama Shaikh: https://github.com/reshamas
+- Tim Head: https://github.com/betatim
 
 ***********
  Copyright


### PR DESCRIPTION
I think something which we haven't done so far, but would be nice to do, is to acknowledge people who contribute to the development of a slep, but are not core contributors.

I'm not sure of the text, or whom to include/exclude, but I thought I could open a PR and see how y'all feel about it. I've included Reshama and Lucy as well since at the time of writing the slep, they're not a part of the to-be-formed "core contributor" team.

I haven't added @cmarmo here since she's an author with #81 on the slep.

So, WDYT?