### PR TITLE
SLEP023: Callback API

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -25,6 +25,7 @@
     slep012/proposal
     slep017/proposal
     slep019/proposal
+    slep023/proposal
 
 .. toctree::
     :maxdepth: 1

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -1,0 +1,144 @@
+.. _slep_023:
+
+=====================
+SLEP023: Callback API
+=====================
+
+:Author: Jérémie du Boisberranger
+:Status: Draft
+:Type: Standards Track
+:Created: 2024-03-01
+
+Abstract
+--------
+
+This SLEP proposes an API to allow users to register callbacks to be called at
+specific points during the training of scikit-learn estimators.
+
+Motivation
+----------
+
+The current scikit-learn API provides a very limited way for users to inspect the steps
+of the training process (`fit`) of an estimator, even less a composition of several
+estimators and meta-estimators. Setting a verbosity level provides some information and
+only a few estimators expose a few public attributes containing some information
+accumulated during training (e.g. `HistGradientBoostingClassifier.train_score_`), and
+that's pretty much it.
+
+Some use cases that have been requested many times on the scikit-learn issue tracker
+which are not possible to achieve with the current API are for instance Progress bars,
+Structured logging, Monitoring, Snapshots, etc. It would also provide a generic and
+consistent API for early stopping, which is currently implemented differently in only a
+few estimators. For such widely requested features, scikit-learn would provide builtin
+callbacks, but users would also be able to implement their own callbacks for less common
+use cases.
+
+By providing a way to gather information during the training process, effectivley making
+scikit-learn implementation of machine learning algorithms more transparent, the
+callback API would also bring a lot of value for educational, testing and debugging
+purposes.
+
+Detailed description
+--------------------
+
+This section discusses the main challenges and the proposed solutions for the callback
+API to be generic and flexible enough despite the wide diversity of scikit-learn
+estimators and meta-estimators.
+
+Callbacks and hooks
+~~~~~~~~~~~~~~~~~~~
+
+This SLEP proposes to define a callback as an object containing methods called at
+specific points of `fit` (hooks). To keep the scope of this SLEP reasonable, only hooks
+called during `fit` are discussed here, but the API could be extended to other methods
+in the future.
+
+One hook is called at the beginning of `fit` (`on_fit_begin`) and one at the
+end (`on_fit_end`) to allow callback initialization and cleanup. A third hook is called
+at the end of each iteration (`on_fit_iter_end`), where an iteration is roughly defined
+as any loop step from the outermost loop in the `fit` method down to a loop over the
+full dataset or batch for online algorithms (e.g. `MiniBatchKMeans`).
+
+Due to the diversity of the estimators in scikit-learn, it's not realistic to define
+specific hooks for each of these kind of iteration, which would end up with estimator
+specific hooks, defeating the purpose of a generic API.
+
+Computation tree
+~~~~~~~~~~~~~~~~
+
+The computation steps of an estimator can be seen as a tree, where the root is the
+beginning of `fit` and nested loops are the different depth levels, each loop step
+being a node. The leaves are the steps of the innermost loop over the full dataset.
+Based on the above section, the `on_fit_iter_end` hook is thus called at each node
+of this tree.
+
+Callbacks need to act differently depending on the depth they are called at. This SLEP
+thus proposes that every estimator hold its computation tree as an attribute, such that
+callbacks can know at which node they are called and act accordingly. Because the tree
+depends on the value of the estimator's hyperparameters, this tree structure is created
+dinamically at the beginning of `fit`. When estimators are nested, the trees are merged,
+the root of the inner estimator being a leaf of the outer estimator.
+
+Performance
+~~~~~~~~~~~
+
+It's inevitable that callbacks will have a performance cost, especially when called
+within cython nogil code. The most important thing is to make sure is that when no
+callbacks are registered the performance is not affected (not acquiring the GIL for
+instance).
+
+In addition, some information given to the `on_fit_iter_end` hook might be expensive to
+compute but is not needed by all callbacks. This SLEP proposes that callbacks must
+explicitly request the information which is expensive to compute, and that the estimator
+gives this information to the hook in a lazy way.
+
+Callback propagation
+~~~~~~~~~~~~~~~~~~~~
+
+When composing estimators and meta-estimators, some callbacks are intuitively expected
+to be applied to all of them. For instance progress bars should be able to report the
+progress of all parts of such compositions. This SLEP proposes that some callbacks have
+the property of being automatically propagated to inner estimators, such that they only
+need to be registered on the outermost estimator.
+
+Parallelism
+~~~~~~~~~~~
+
+Many scikit-learn estimators use multiprocessing or multithreading which can make the
+design of callbacks more complex, because callbacks don't share their state between
+processes. The file system or `multiprocessing.Manager` objects  for instance should be
+used to overcome this issue.
+
+Implementation
+--------------
+
+An implementation of this SLEP is being developed in :pr:`27663`, which targets the
+`callbacks` feature branch. In this PR, only the base infrastructure and one builtin
+callback (progress bars) are implemented. Other callbacks and documention will be
+added incrementally in follow-up PRs.
+
+Discussion
+----------
+
+The goal of this SLEP is to provide a common solution for a wide range of use cases
+discussed in many long-standing issues and PRs, going back to :issue:`78`. Here are
+some related issues and PRs: :issue:`4863`, :issue:`7574`, :issue:`8433`,
+:issue:`8994`, :issue:`9136`, :issue:`10489`, :issue:`10973`, :issue:`12325`,
+:issue:`14338`, :issue:`14531`, :issue:`16118`, :issue:`18507`, :issue:`18748`,
+:issue:`18773`, :issue:`20127`, :issue:`20668`, :issue:`23156`, :issue:`24524`,
+:issue:`25187`, :issue:`26395`, :issue:`26494`, :issue:`26532`, :pr:`1171`, :pr:`3817`,
+:pr:` 8317`, :pr:`16925`, :pr:`22000`.
+
+References and Footnotes
+------------------------
+
+.. [1] Each SLEP must either be explicitly labeled as placed in the public
+   domain (see this SLEP as an example) or licensed under the `Open Publication
+   License`_.
+
+.. _Open Publication License: https://www.opencontent.org/openpub/
+
+Copyright
+---------
+
+This document has been placed in the public domain. [1]_

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -127,7 +127,7 @@ some related issues and PRs: :issue:`4863`, :issue:`7574`, :issue:`8433`,
 :issue:`14338`, :issue:`14531`, :issue:`16118`, :issue:`18507`, :issue:`18748`,
 :issue:`18773`, :issue:`20127`, :issue:`20668`, :issue:`23156`, :issue:`24524`,
 :issue:`25187`, :issue:`26395`, :issue:`26494`, :issue:`26532`, :pr:`1171`, :pr:`3817`,
-:pr:` 8317`, :pr:`16925`, :pr:`22000`.
+:pr:`8317`, :pr:`16925`, :pr:`22000`.
 
 References and Footnotes
 ------------------------

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -101,13 +101,13 @@ To add callback support to an estimator, scikit-learn provides three components:
 
   The `CallbackContext` class exposes the following methods:
 
-  - `eval_on_fit_task_begin`, to evaluate the callbacks at the beginning of the task.
-  - `eval_on_fit_task_end`, to evaluate the callbacks at the end of the task.
+  - `call_on_fit_task_begin`, to call the callbacks at the beginning of the task.
+  - `call_on_fit_task_end`, to call the callbacks at the end of the task.
   - `subcontext`, to create a child `CallbackContext` for a subtask.
   - `propagate_callbacks`, to propagate the callback context and the auto-propagated
     callbacks from a meta-estimator to its sub-estimators.
 
-  When a callback is evaluated for a given task, it receives the corresponding context
+  When a callback is called for a given task, it receives the corresponding context
   which exposes attributes that provide information about the task being executed to be
   used by the callback to adapt its behavior. It also receives all the information that
   the estimator is able to provide about the state of the fitting process at this task.
@@ -137,22 +137,18 @@ A typical implementation of callback support in an estimator would look like thi
             callback_ctx = self._init_callback_context(
                 task_name="fit", max_subtasks=self.n_iter
             )
-            callback_ctx.eval_on_fit_task_begin()
+            callback_ctx.call_on_fit_task_begin()
 
             for i in range(self.n_iter):
                 subcontext = callback_ctx.subcontext(
                     task_name=f"iteration {i}", task_id=i
-                ).eval_on_fit_task_begin(
-                  data={"X_train": X, "y_train": y},
-                )
+                ).call_on_fit_task_begin(X=X, y=y)
 
                 # <computation part of the estimator>
 
-                subcontext.eval_on_fit_task_end(
-                    data={"X_train": X, "y_train": y},
-                )
+                subcontext.call_on_fit_task_end(X=X, y=y)
 
-            callback_ctx.eval_on_fit_task_end()
+            callback_ctx.call_on_fit_task_end()
 
             return self
 
@@ -165,8 +161,8 @@ Callbacks must implement the following protocol:
 
     class FitCallback(Protocol):
         def setup(self, context): ...
-        def on_fit_task_begin(self, context, *, data=None, metadata=None, fitted_estimator=None): ...
-        def on_fit_task_end(self, context, *, data=None, metadata=None, fitted_estimator=None): ...
+        def on_fit_task_begin(self, context, *, X=None, y=None, metadata=None, fitted_estimator=None): ...
+        def on_fit_task_end(self, context, *, X=None, y=None, metadata=None, fitted_estimator=None): ...
         def teardown(self, context): ...
 
 The `setup` and `teardown` hooks are called at the beginning and end of `fit` and should
@@ -178,17 +174,18 @@ The keyword arguments received by the `on_fit_task_begin` and `on_fit_task_end`
 hooks contain all the available information provided by the estimator about the state of
 the fitting process at this task:
 
-- "data": a dictionary containing the training and validation data.
+- "X": the training data.
+
+- "y": the training target.
 
 - "metadata": a dictionary containing training and validation metadata, e.g. sample
-  weights.
+  weights, `X_val`, `y_val`, etc.
 
 - "fitted_estimator": an estimator instance that is ready to predict, transform, etc.
   as if `fit` stopped at the end of this task.
 
-Note that some estimators may not be able to provide all of these information for every
-task. That list is likely to be extended in the future so callbacks hooks should be
-tolerant to missing keys.
+Note that some estimators may not be able to provide values for all of these keys for
+every task.
 
 Auto-propagated callbacks must implement a small extension of this protocol:
 
@@ -211,11 +208,11 @@ estimators and meta-estimators.
 Protocol extensions
 ~~~~~~~~~~~~~~~~~~~
 
-To keep the scope of this SLEP reasonable, it only considers callbacks evaluated during
+To keep the scope of this SLEP reasonable, it only considers callbacks called during
 `fit` but the API could be extended to other methods (e.g. `predict` or `transform`) or
 unbound functions (e.g. `cross_validate`) in the future.
 PR `#33404<https://github.com/scikit-learn/scikit-learn/pull/33404>`_ for instance
-proposes a new protocol for callback evaluation in unbound functions.
+proposes a new protocol for callback support in unbound functions.
 
 Task granularity
 ~~~~~~~~~~~~~~~~

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -21,17 +21,17 @@ Motivation
 The current scikit-learn API provides a very limited way for users to inspect the steps
 of the training process (`fit`) of an estimator, even less a composition of several
 estimators and meta-estimators. Setting a verbosity level provides some information and
-only a few estimators expose a few public attributes containing some information
-accumulated during training (e.g. `HistGradientBoostingClassifier.train_score_`), and
-that's pretty much it.
+only a few estimators expose public attributes containing some information accumulated
+during training (e.g. `HistGradientBoostingClassifier.train_score_`), and that's pretty
+much it.
 
 Some use cases that have been requested many times on the scikit-learn issue tracker
-which are not possible to achieve with the current API are for instance Progress bars,
-Structured logging, Monitoring, Snapshots, etc. It could also provide a generic and
-consistent API for early stopping, which is currently implemented differently in only a
-few estimators. For such widely requested features, scikit-learn would provide builtin
-callbacks, but users would also be able to implement their own callbacks for less common
-use cases.
+which are not possible to achieve with the current API are for instance progress bars,
+structured logging, metric monitoring, snapshots, etc. The callback API could also
+provide a generic and consistent API for early stopping, which is currently implemented
+differently in only a few estimators. For such widely requested features, scikit-learn
+will provide builtin callbacks, but users would also be able to implement their own
+callbacks for less common use cases.
 
 By providing a way to gather information during the training process, effectivley making
 scikit-learn implementation of machine learning algorithms more transparent, the
@@ -41,136 +41,185 @@ purposes.
 Public interfaces
 -----------------
 
-This sections describes the proposed public interfaces for the callback API. They are
-divided into three subsets which target different kind of users: the end users of
-scikit-learn, the third-party developers implementing custom estimators and the
-third-party developers implementing custom callbacks.
+This sections describes the proposed public interfaces for the callbacks. They are
+divided into three subsets which target different kinds of users:
+
+- the end users of scikit-learn
+- the scikit-learn and third-party developers implementing estimators
+- the scikit-learn and third-party developers implementing callbacks
 
 Using callbacks
 ~~~~~~~~~~~~~~~
 
-Callbacks are objects exposed in the `sklearn.callbacks` module. They can be registered
-to an estimator using their `set_callbacks` method::
+Callbacks are objects that can be registered to an estimator to be called at specific
+points during `fit`, gathering information about the training process. scikit-learn
+provides a set of builtin callbacks for common use cases, exposed in the
+`sklearn.callbacks` module.
+
+Callbacks can be registered to an estimator using its `set_callbacks` method:
+
+.. code-block:: python
 
     from sklearn.linear_model import LogisticRegression
     from sklearn.callbacks import ProgressBar
 
-    clf = LogisticRegression()
     callback = ProgressBar()
+    clf = LogisticRegression()
     clf.set_callbacks(callback)
     clf.fit(X, y)
 
 When composing estimators and meta-estimators, some callbacks are intuitively expected
-to be applied to all of them. For instance progress bars should be able to report the
-progress of all parts of such compositions. This SLEP proposes that some callbacks have
-the property of being automatically propagated to inner estimators, such that they only
-need to be registered on the outermost estimator.
+to only be applied to some of them (e.g. early stopping on inner estimators) while
+others are expected to be applied to all of them (e.g. progress bars). This SLEP
+proposes that some callbacks (referred to as "auto-propagated") have the property of
+being automatically propagated down to sub-estimators, such that they only need to be 
+registered on the outermost meta-estimator:
 
-The callback protocol
-~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: python
 
-Callbacks must implement the following protocol::
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.model_selection import GridSearchCV
+    from sklearn.callbacks import EarlyStopping, ProgressBar
 
-    class Callback(Protocol):
-        def on_fit_begin(self, estimator)
-        def on_fit_task_end(self, estimator, context, **kwargs)
-        def on_fit_end(self, estimator, context)
-
-The `on_fit_begin` hook is called at the beginning of `fit` and can be used to
-initialize the callback. The `on_fit_end` hook is called at the end of `fit` and can be
-used to cleanup the callback. The `on_fit_task_end` hook is called at the end of each
-task performed during `fit`. Usually tasks correspond to iterations of loops during
-`fit` and nested loops correspond to nested tasks, but in general a task can be any
-unit of work defined by the estimator.
-
-The `**kwargs` parameters receives all the information provided by the estimator about
-the state of the fitting process at this task. Possible keys are:
-
-- "data": a dictionary containing the training and validation data.
-
-- "stopping_criterion": a float. Usually iterations stop when
-  `stopping_criterion <= tol`.
-
-- "tol": a float. Tolerance for the stopping criterion.
-
-- "from_reconstruction_attributes": an estimator instance that is ready to predict,
-  transform, etc ... estimator as if the fit stopped at the end of this task.
-
-- "fit_state": a dictionary containing model specific quantities updated during fit.
-  This is not meant to be used by generic callbacks but by a callback designed for a
-  specific estimator instead.
-
-Note that all these keys are optional and that estimators are not required to provide
-all of them and within a single estimator different tasks may provide different keys.
-
-The `context` parameter is an instance of `CallbackContext`, which provides information
-about the current state of the computation, described in more details below.
+    clf = LogisticRegression().set_callbacks(EarlyStopping())
+    clf = GridSearchCV(clf, param_grid).set_callbacks(ProgressBar())
+    clf.fit(X, y)
 
 Callback support in estimators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To add callback support to an estimator, scikit-learn provides three components:
 
+- a `CallbackContext` class that is used to manage the callbacks during `fit`. Instances
+  of this class represent contexts of tasks being executed, where tasks are unit of work
+  defined by the estimator. There is one `CallbackContext` for each task. Tasks (and
+  therefore callback contexts) have a natural tree structure, where each task can be
+  decomposed into subtasks and so on, with the root task being the whole `fit` task.
+  Usually tasks correspond to iterations of loops during `fit` and nested loops
+  correspond to nested tasks, but in general a task can be any unit of work defined by
+  the estimator.
+
+  The `CallbackContext` class exposes the following methods:
+
+  - `eval_on_fit_task_begin`, to evaluate the callbacks at the beginning of the task.
+  - `eval_on_fit_task_end`, to evaluate the callbacks at the end of the task.
+  - `subcontext`, to create a child `CallbackContext` for a subtask.
+  - `propagate_callbacks`, to propagate the callback context and the auto-propagated
+    callbacks from a meta-estimator to its sub-estimators.
+
+  When a callback is evaluated for a given task, it receives the corresponding context
+  which exposes attributes that provide information about the task being executed to be
+  used by the callback to adapt its behavior.
+
 - a `CallbackSupportMixin` class that the estimator should inherit from. This mixin
-  exposes the `set_callbacks` method.
+  exposes the following methods:
 
-- a `with_callback_context` decorator to wrap the `fit` method of the estimator. This
-  decorator takes care of the setup and teardown of callbacks and makes sure they are
-  properly executed even if an exception is raised during `fit`.
+  - `set_callbacks`, to register callbacks to the estimator.
+  - `_init_callback_context`, to create the root callback context for the estimator
+    and setup the callbacks for the estimator.
 
-- a `CallbackContext` class that is used to manage the callbacks during `fit`. An
-  instance of this class is created by the `with_callback_context` decorator at the
-  beginning of `fit` and can be accessed as the `_callback_fix_ctx` of the estimator.
+- a `with_fit_callbacks` decorator that the estimator should use to decorate the
+  `fit` method. It runs `fit` in a try-finally block to ensure that callbacks are
+  properly torn down no matter what happens during `fit`.
 
-  It exposes three methods responsible for calling the hooks of the registered
-  callbacks: `eval_on_fit_begin`, `eval_on_fit_task_end` and `eval_on_fit_end`. In
-  addition, it exposes a `propagate_callbacks` method to propagate callbacks from a
-  meta-estimator to its inner estimators. Finally it exposes a `subcontext` method to
-  create a `CallbackContext` instance for a subtask.
+A typical implementation of callback support in an estimator would look like this:
 
-  The `CallbackContext` instance also exposes attributes that provide information about
-  the task being executed and its position in the hierarchy of tasks that callbacks can
-  use to adapt their behavior.
-
-A typical implementation of callback support in an estimator would look like this::
+.. code-block:: python
 
     from sklearn.base import BaseEstimator
-    from sklearn.callback import CallbackSupportMixin, with_callback_context
+    from sklearn.callback import CallbackSupportMixin, with_fit_callbacks
 
     class MyEstimator(CallbackSupportMixin, BaseEstimator):
 
-        @with_callback_context
+        @with_fit_callbacks
         def fit(self, X, y):
-            callback_ctx = self._callback_fit_ctx
-            callback_ctx.eval_on_fit_begin(estimator=self)
-            for i in range(self.n_iter):
-                subcontext = callback_ctx.subcontext(task_id=i)
+            callback_ctx = self._init_callback_context(
+                task_name="fit", max_subtasks=self.n_iter
+            )
+            callback_ctx.eval_on_fit_task_begin()
 
-                <computation part of the estimator>
+            for i in range(self.n_iter):
+                subcontext = callback_ctx.subcontext(
+                    task_name=f"iteration {i}", task_id=i
+                ).eval_on_fit_task_begin()
+
+                # <computation part of the estimator>
 
                 subcontext.eval_on_fit_task_end(
-                    estimator=self,
-                    context=subcontext,
+                    data={"X_train": X, "y_train": y},
                 )
+
+            callback_ctx.eval_on_fit_task_end()
 
             return self
 
-Design considerations
----------------------
+The callback protocol
+~~~~~~~~~~~~~~~~~~~~~
+
+Callbacks must implement the following protocol:
+
+.. code-block:: python
+
+    class FitCallback(Protocol):
+        def setup(self, context): ...
+        def on_fit_task_begin(self, context, **kwargs): ...
+        def on_fit_task_end(self, context, **kwargs): ...
+        def teardown(self, context): ...
+
+The `setup` and `teardown` hooks are called at the beginning and end of `fit` and should
+be used to setup and tear down the callback for the estimator. The `on_fit_task_begin`
+and `on_fit_task_end` hooks are called at the beginning and end of each task performed
+during `fit`, including the root task.
+
+The extra keyword arguments received by the `on_fit_task_begin` and `on_fit_task_end`
+hooks contain all the information provided by the estimator about the state of the
+fitting process at this task. The possible keys are:
+
+- "data": a dictionary containing the training and validation data.
+
+- "metadata": a dictionary containing training and validation metadata, e.g. sample
+  weights.
+
+- "fitted_estimator": an estimator instance that is ready to predict, transform, etc.
+  as if `fit` stopped at the end of this task.
+
+Note that estimators are not required to provide all of them and within a single
+estimator different tasks may provide different subsets of these keys.
+
+Auto-propagated callbacks must implement a small extension of this protocol:
+
+.. code-block:: python
+
+    class AutoPropagatedCallback(FitCallback, Protocol):
+        @property
+        def max_propagation_depth(self): ...
+
+`max_propagation_depth` defines the maximum nesting level of sub-estimators to propagate
+the callback to.
+
+Considerations
+--------------
 
 This section discusses the main challenges and the proposed solutions for the callback
 API to be generic and flexible enough despite the wide diversity of scikit-learn
 estimators and meta-estimators.
 
-Callback hooks
-~~~~~~~~~~~~~~
+Protocol extensions
+~~~~~~~~~~~~~~~~~~~
 
-To keep the scope of this SLEP reasonable, it only considers callbacks acting during
-`fit` but the API could be extended to other methods in the future.
+To keep the scope of this SLEP reasonable, it only considers callbacks evaluated during
+`fit` but the API could be extended to other methods (e.g. `predict` or `transform`) or
+unbound functions (e.g. `cross_validate`) in the future.
+PR `#33404<https://github.com/scikit-learn/scikit-learn/pull/33404>`_ for instance
+proposes a new protocol for callback evaluation in unbound functions.
 
-In addition, the smallest task granularity considered in this SLEP are tasks dealing
-with the full dataset. For instance the `on_fit_task_end` hook is called at the end of
-a loop iterating over the full dataset but not at the end of each step of such loop.
+Task granularity
+~~~~~~~~~~~~~~~~
+
+The smallest task granularity considered in this SLEP is tasks dealing with the full
+dataset. For instance the `on_fit_task_end` hook is called at the end of a loop
+iterating over the full dataset but not at the end of each step of such loop. A smaller
+granularity would not allow the same level of flexibility.
 
 Performance
 ~~~~~~~~~~~
@@ -180,10 +229,10 @@ within cython nogil code. The most important thing is to make sure that when no
 callbacks are registered the performance is not affected (not acquiring the GIL for
 instance).
 
-Moreover, some information given to the `on_fit_task_end` hook might be expensive to
-compute but is not needed by all callbacks. This SLEP proposes that callbacks must
-explicitly request the information which is expensive to compute, and that the estimator
-gives this information to the hook in a lazy way.
+Moreover, some information given to the hooks might be expensive to compute but is not
+needed by all callbacks. This SLEP proposes that callbacks must explicitly request the
+information which is expensive to compute, and that the estimator passes it to the hooks
+in a lazy way.
 
 Parallelism
 ~~~~~~~~~~~
@@ -192,6 +241,13 @@ Many scikit-learn estimators use multiprocessing or multithreading which can mak
 design of callbacks more complex, because callbacks don't share their state between
 processes. The file system or `multiprocessing.Manager` objects for instance should be
 used to overcome this issue.
+
+Non-callback-aware meta-estimators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Callbacks can be registered on estimators that are passed to meta-estimators or unbound
+functions that do not support callbacks. In this case, callbacks should not break the
+workflow but might not provide full value and perform their work sub-optimally.
 
 Additional dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -203,22 +259,44 @@ used, similarly to the display objects.
 Implementation
 --------------
 
-An implementation of this SLEP is being developed in :pr:`28760`, which targets the
-`callbacks` feature branch. In this PR, only the base infrastructure and one builtin
-callback (progress bars) are implemented. Other callbacks and documention will be
-added incrementally in follow-up PRs.
+An implementation of this SLEP is being developed in the `callbacks` feature branch.
+PR `#33322<https://github.com/scikit-learn/scikit-learn/pull/33322>`_ keeps an updated
+diff againt the `main` branch. It currently contains the callback framework and the
+progress bar callback.
 
 Discussion
 ----------
 
 The goal of this SLEP is to provide a common solution for a wide range of use cases
-discussed in many long-standing issues and PRs, going back to :issue:`78`. Here are
-some related issues and PRs: :issue:`4863`, :issue:`7574`, :issue:`8433`,
-:issue:`8994`, :issue:`9136`, :issue:`10489`, :issue:`10973`, :issue:`12325`,
-:issue:`14338`, :issue:`14531`, :issue:`16118`, :issue:`18507`, :issue:`18748`,
-:issue:`18773`, :issue:`20127`, :issue:`20668`, :issue:`23156`, :issue:`24524`,
-:issue:`25187`, :issue:`26395`, :issue:`26494`, :issue:`26532`, :pr:`1171`, :pr:`3817`,
-:pr:`8317`, :pr:`16925`, :pr:`22000`.
+discussed in many long-standing issues and PRs, going back to issue
+`#78<https://github.com/scikit-learn/scikit-learn/issues/78>`_. Here are some related
+issues and PRs: `#4863<https://github.com/scikit-learn/scikit-learn/issues/4863>`_,
+`#7574<https://github.com/scikit-learn/scikit-learn/issues/7574>`_,
+`#8433<https://github.com/scikit-learn/scikit-learn/issues/8433>`_,
+`#8994<https://github.com/scikit-learn/scikit-learn/issues/8994>`_,
+`#9136<https://github.com/scikit-learn/scikit-learn/issues/9136>`_,
+`#10489<https://github.com/scikit-learn/scikit-learn/issues/10489>`_,
+`#10973<https://github.com/scikit-learn/scikit-learn/issues/10973>`_,
+`#12325<https://github.com/scikit-learn/scikit-learn/issues/12325>`_,
+`#14338<https://github.com/scikit-learn/scikit-learn/issues/14338>`_,
+`#14531<https://github.com/scikit-learn/scikit-learn/issues/14531>`_,
+`#16118<https://github.com/scikit-learn/scikit-learn/issues/16118>`_,
+`#18507<https://github.com/scikit-learn/scikit-learn/issues/18507>`_,
+`#18748<https://github.com/scikit-learn/scikit-learn/issues/18748>`_,
+`#18773<https://github.com/scikit-learn/scikit-learn/issues/18773>`_,
+`#20127<https://github.com/scikit-learn/scikit-learn/issues/20127>`_,
+`#20668<https://github.com/scikit-learn/scikit-learn/issues/20668>`_,
+`#23156<https://github.com/scikit-learn/scikit-learn/issues/23156>`_,
+`#24524<https://github.com/scikit-learn/scikit-learn/issues/24524>`_,
+`#25187<https://github.com/scikit-learn/scikit-learn/issues/25187>`_,
+`#26395<https://github.com/scikit-learn/scikit-learn/issues/26395>`_,
+`#26494<https://github.com/scikit-learn/scikit-learn/issues/26494>`_,
+`#26532<https://github.com/scikit-learn/scikit-learn/issues/26532>`_,
+`#1171<https://github.com/scikit-learn/scikit-learn/pull/1171>`_,
+`#3817<https://github.com/scikit-learn/scikit-learn/pull/3817>`_,
+`#8317<https://github.com/scikit-learn/scikit-learn/pull/8317>`_,
+`#16925<https://github.com/scikit-learn/scikit-learn/pull/16925>`_,
+`#22000<https://github.com/scikit-learn/scikit-learn/pull/22000>`_.
 
 References and Footnotes
 ------------------------

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -166,8 +166,15 @@ Parallelism
 
 Many scikit-learn estimators use multiprocessing or multithreading which can make the
 design of callbacks more complex, because callbacks don't share their state between
-processes. The file system or `multiprocessing.Manager` objects  for instance should be
+processes. The file system or `multiprocessing.Manager` objects for instance should be
 used to overcome this issue.
+
+Additional dependencies
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Some callbacks may require additional dependencies (e.g. `rich` for progress bars).
+Such dependencies must be optional and only imported when the corresponding callback is
+used, similarly to the display objects.
 
 Implementation
 --------------

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -101,7 +101,7 @@ the state of the fitting process at this task. Possible keys are:
   specific estimator instead.
 
 Note that all these keys are optional and that estimators are not required to provide
-all of them and within a single estimator different tasks may provide different keys.
+all of them. Different tasks may provide different keys within a single estimator.
 
 The `context` parameter is an instance of `CallbackContext`, which provides information
 about the current state of the computation, described in more details below.

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -73,7 +73,7 @@ Callbacks must implement the following protocol::
 
     class Callback(Protocol):
         def on_fit_begin(self, estimator)
-        def on_fit_task_end(self, estimator, context, **kargs)
+        def on_fit_task_end(self, estimator, context, **kwargs)
         def on_fit_end(self, estimator, context)
 
 The `on_fit_begin` hook is called at the beginning of `fit` and can be used to

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -42,7 +42,7 @@ Public interfaces
 -----------------
 
 This sections describes the proposed public interfaces for the callback API. They are
-divided into three substets which target different kind of users: the end users of
+divided into three subsets which target different kind of users: the end users of
 scikit-learn, the third-party developers implementing custom estimators and the
 third-party developers implementing custom callbacks.
 

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -27,7 +27,7 @@ that's pretty much it.
 
 Some use cases that have been requested many times on the scikit-learn issue tracker
 which are not possible to achieve with the current API are for instance Progress bars,
-Structured logging, Monitoring, Snapshots, etc. It would also provide a generic and
+Structured logging, Monitoring, Snapshots, etc. It could also provide a generic and
 consistent API for early stopping, which is currently implemented differently in only a
 few estimators. For such widely requested features, scikit-learn would provide builtin
 callbacks, but users would also be able to implement their own callbacks for less common
@@ -38,46 +38,115 @@ scikit-learn implementation of machine learning algorithms more transparent, the
 callback API would also bring a lot of value for educational, testing and debugging
 purposes.
 
-Detailed description
---------------------
+Public interfaces
+-----------------
+
+This sections describes the proposed public interfaces for the callback API. They are
+divided into three substets which target different kind of users: the end users of
+scikit-learn, the third-party developers implementing custom estimators and the
+third-party developers implementing custom callbacks.
+
+Using callbacks
+~~~~~~~~~~~~~~~
+
+Callbacks are objects exposed in the `sklearn.callbacks` module. They can be registered
+to an estimator using their `set_callbacks` method::
+
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.callbacks import ProgressBar
+
+    clf = LogisticRegression()
+    callback = ProgressBar()
+    clf.set_callbacks(callback)
+    clf.fit(X, y)
+
+When composing estimators and meta-estimators, some callbacks are intuitively expected
+to be applied to all of them. For instance progress bars should be able to report the
+progress of all parts of such compositions. This SLEP proposes that some callbacks have
+the property of being automatically propagated to inner estimators, such that they only
+need to be registered on the outermost estimator.
+
+The callback protocol
+~~~~~~~~~~~~~~~~~~~~~
+
+Callbacks must implement the following protocol::
+
+    class Callback(Protocol):
+        def on_fit_begin(self, estimator)
+        def on_fit_task_end(self, estimator, context, **kargs)
+        def on_fit_end(self, estimator, context)
+
+The `on_fit_begin` hook is called at the beginning of `fit` and can be used to
+initialize the callback. The `on_fit_end` hook is called at the end of `fit` and can be
+used to cleanup the callback. The `on_fit_task_end` hook is called at the end of each
+task performed during `fit`. Usually tasks correspond to iterations of loops during
+`fit` and nested loops correspond to nested tasks, but in general a task can be any
+unit of work defined by the estimator.
+
+The `context` parameter is an instance of `CallbackContext`, which provides information
+about the current state of the computation, described in more details below.
+
+Callback support in estimators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To add callback support to an estimator, scikit-learn provides three components:
+
+- a `CallbackSupportMixin` class that the estimator should inherit from. This mixin
+  exposes the `set_callbacks` method.
+
+- a `with_callback_context` decorator to wrap the `fit` method of the estimator. This
+  decorator takes care of the setup and teardown of callbacks and makes sure they are
+  properly executed even if an exception is raised during `fit`.
+
+- a `CallbackContext` class that is used to manage the callbacks during `fit`. An
+  instance of this class is created by the `with_callback_context` decorator at the
+  beginning of `fit` and can be accessed as the `_callback_fix_ctx` of the estimator.
+
+  It exposes three methods responsible for calling the hooks of the registered
+  callbacks: `evel_on_fit_begin`, `evel_on_fit_task_end` and `eval_on_fit_end`. In
+  addition, it exposes a `propagate_callbacks` method to propagate callbacks from a
+  meta-estimator to its inner estimators. Finally it exposes a `subcontext` method to
+  create a `CallbackContext` instance for a subtask.
+
+A typical implementation of callback support in an estimator would look like this::
+
+    from sklearn.base import BaseEstimator
+    from sklearn.callback import CallbackSupportMixin, with_callback_context
+
+    class MyEstimator(CallbackSupportMixin, BaseEstimator):
+
+        @with_callback_context
+        def fit(self, X, y):
+            callback_ctx = self._callback_fit_ctx
+            callback_ctx.eval_on_fit_begin(estimator=self)
+            for i in range(self.n_iter):
+                subcontext = callback_ctx.subcontext(task_id=i)
+
+                <computation part of the estimator>
+
+                subcontext.eval_on_fit_task_end(
+                    estimator=self,
+                    context=subcontext,
+                )
+
+            return self
+
+Design considerations
+---------------------
 
 This section discusses the main challenges and the proposed solutions for the callback
 API to be generic and flexible enough despite the wide diversity of scikit-learn
 estimators and meta-estimators.
 
-Callbacks and hooks
-~~~~~~~~~~~~~~~~~~~
+Callback hooks
+~~~~~~~~~~~~~~
 
-This SLEP proposes to define a callback as an object containing methods called at
-specific points of `fit` (hooks). To keep the scope of this SLEP reasonable, only hooks
-called during `fit` are discussed here, but the API could be extended to other methods
-in the future.
+To keep the scope of this SLEP reasonable, it only considers callbacks acting during
+`fit` but the API could be extended to other methods in the future.
 
-One hook is called at the beginning of `fit` (`on_fit_begin`) and one at the
-end (`on_fit_end`) to allow callback initialization and cleanup. A third hook is called
-at the end of each iteration (`on_fit_iter_end`), where an iteration is roughly defined
-as any loop step from the outermost loop in the `fit` method down to a loop over the
-full dataset or batch for online algorithms (e.g. `MiniBatchKMeans`).
-
-Due to the diversity of the estimators in scikit-learn, it's not realistic to define
-specific hooks for each of these kind of iteration, which would end up with estimator
-specific hooks, defeating the purpose of a generic API.
-
-Computation tree
-~~~~~~~~~~~~~~~~
-
-The computation steps of an estimator can be seen as a tree, where the root is the
-beginning of `fit` and nested loops are the different depth levels, each loop step
-being a node. The leaves are the steps of the innermost loop over the full dataset.
-Based on the above section, the `on_fit_iter_end` hook is thus called at each node
-of this tree.
-
-Callbacks need to act differently depending on the depth they are called at. This SLEP
-thus proposes that every estimator hold its computation tree as an attribute, such that
-callbacks can know at which node they are called and act accordingly. Because the tree
-depends on the value of the estimator's hyperparameters, this tree structure is created
-dinamically at the beginning of `fit`. When estimators are nested, the trees are merged,
-the root of the inner estimator being a leaf of the outer estimator.
+In addition, the smallest task granularity considered in this SLEP are tasks dealing
+with the full dataset. For instance the `on_fit_task_end` hook is called at the end of
+a loop iterating over the full dataset but not at the end of each step of such loop.
 
 Performance
 ~~~~~~~~~~~
@@ -87,19 +156,10 @@ within cython nogil code. The most important thing is to make sure is that when 
 callbacks are registered the performance is not affected (not acquiring the GIL for
 instance).
 
-In addition, some information given to the `on_fit_iter_end` hook might be expensive to
+Moreover, some information given to the `on_fit_task_end` hook might be expensive to
 compute but is not needed by all callbacks. This SLEP proposes that callbacks must
 explicitly request the information which is expensive to compute, and that the estimator
 gives this information to the hook in a lazy way.
-
-Callback propagation
-~~~~~~~~~~~~~~~~~~~~
-
-When composing estimators and meta-estimators, some callbacks are intuitively expected
-to be applied to all of them. For instance progress bars should be able to report the
-progress of all parts of such compositions. This SLEP proposes that some callbacks have
-the property of being automatically propagated to inner estimators, such that they only
-need to be registered on the outermost estimator.
 
 Parallelism
 ~~~~~~~~~~~
@@ -112,7 +172,7 @@ used to overcome this issue.
 Implementation
 --------------
 
-An implementation of this SLEP is being developed in :pr:`27663`, which targets the
+An implementation of this SLEP is being developed in :pr:`28760`, which targets the
 `callbacks` feature branch. In this PR, only the base infrastructure and one builtin
 callback (progress bars) are implemented. Other callbacks and documention will be
 added incrementally in follow-up PRs.

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -19,30 +19,30 @@ Motivation
 ----------
 
 The current scikit-learn API provides a very limited way for users to inspect the steps
-of the training process (`fit`) of an estimator, even less a composition of several
-estimators and meta-estimators. Setting a verbosity level provides some information and
-only a few estimators expose public attributes containing some information accumulated
-during training (e.g. `HistGradientBoostingClassifier.train_score_`), and that's pretty
-much it.
+of the training process (`fit`) of an estimator, and even less so when several
+estimators and meta-estimators are composed. Setting a verbosity level provides some
+information and only a few estimators expose public attributes containing some
+information accumulated during training
+(e.g. `HistGradientBoostingClassifier.train_score_`), and that's pretty much it.
 
 Some use cases that have been requested many times on the scikit-learn issue tracker
 which are not possible to achieve with the current API are for instance progress bars,
 structured logging, metric monitoring, snapshots, etc. A callback API could also provide
 a generic and consistent API for early stopping, which is currently implemented
 differently in only a few estimators. For such widely requested features, scikit-learn
-will provide builtin callbacks, but users would also be able to implement their own
+will provide built-in callbacks, but users would also be able to implement their own
 callbacks for less common use cases.
 
-By providing a way to gather information during the training process, effectivley making
-scikit-learn implementation of machine learning algorithms more transparent, the
-callback API would also bring a lot of value for educational, testing and debugging
+By providing a way to gather information during the training process, effectively making
+the scikit-learn implementation of machine learning algorithms more transparent, the
+callback API would also bring a lot of value for educational, testing, and debugging
 purposes.
 
 Public interfaces
 -----------------
 
-This sections describes the proposed public interfaces for the callbacks. They are
-divided into three subsets which target different kinds of users:
+This section describes the proposed public interfaces for callbacks. They are divided
+into three subsets which target different kinds of users:
 
 - the end users of scikit-learn
 - the scikit-learn and third-party developers implementing estimators
@@ -51,12 +51,12 @@ divided into three subsets which target different kinds of users:
 Using callbacks
 ~~~~~~~~~~~~~~~
 
-Callbacks are objects that can be registered to an estimator to be called at specific
+Callbacks are objects that can be registered on an estimator to be called at specific
 points during fit, gathering information about the training process. scikit-learn
-provides a set of builtin callbacks for common use cases, exposed in the
+provides a set of built-in callbacks for common use cases, exposed in the
 `sklearn.callback` module.
 
-Callbacks can be registered to an estimator using its `set_callbacks` method:
+Callbacks can be registered on an estimator using its `set_callbacks` method:
 
 .. code-block:: python
 
@@ -93,7 +93,7 @@ To add callback support to an estimator, scikit-learn provides three components:
 
 - `CallbackContext`: a class that is used to manage the callbacks during fit.
   Instances of this class represent contexts of tasks being executed, where tasks are
-  unit of work defined by the estimator. There is one `CallbackContext` for each task.
+  units of work defined by the estimator. There is one `CallbackContext` for each task.
   Tasks (and therefore callback contexts) have a natural tree structure, where each task
   can be decomposed into subtasks and so on, with the root task being the whole fit
   task. Usually tasks correspond to iterations of loops during fit and nested loops
@@ -116,9 +116,9 @@ To add callback support to an estimator, scikit-learn provides three components:
 - `CallbackSupportMixin`: a class that the estimator should inherit from. This mixin
   exposes the following methods:
 
-  - `set_callbacks`, to register callbacks to the estimator.
+  - `set_callbacks`, to register callbacks on the estimator.
   - `_init_callback_context`, to create the root callback context for the estimator
-    and setup the callbacks for the estimator.
+    and set up the callbacks for the estimator.
 
 - `with_callbacks`: a decorator that the estimator should use to decorate the fit
   method. It runs fit in a try-finally block to ensure that callbacks are properly
@@ -168,7 +168,7 @@ Callbacks must implement the following
         def teardown(self, context): ...
 
 The `setup` and `teardown` hooks are called at the beginning and end of fit and should
-be used to setup and tear down the callback for the estimator. The `on_fit_task_begin`
+be used to set up and tear down the callback for the estimator. The `on_fit_task_begin`
 and `on_fit_task_end` hooks are called at the beginning and end of each task performed
 during fit, including the root task.
 
@@ -203,9 +203,8 @@ the callback to.
 Example traces of hook calls
 ----------------------------
 
-This section provides examples of traces of callback hook calls in different scenarios.
-First let's consider the case where a callback is registered on an estimator that has a
-single level of iterations:
+This section gives example traces of callback hook calls in different scenarios. First,
+consider a callback registered on an estimator with a single level of iterations:
 
 .. code-block:: python
 
@@ -224,9 +223,9 @@ single level of iterations:
     teardown by MaxIterEstimator for fit
 
 It doesn't matter whether `MyCallback` is auto-propagated or not since there is no
-sub-estimator to propagate it to in that case. Then, let's consider the case where the
-estimator from the previous example is used in a meta-estimator that fits clones of its
-sub-estimator for different cross-validation folds:
+sub-estimator to propagate it to in that case. Next, consider the case where the
+estimator from the previous example is wrapped in a meta-estimator that fits clones of
+that sub-estimator for different cross-validation folds:
 
 .. code-block:: python
 
@@ -252,15 +251,15 @@ sub-estimator for different cross-validation folds:
     on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
     teardown by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
 
-The trace is similar to the first example except that it is repeated for each fold. In
-particular the setup and tear down are performed for each fit of the sub-estimator.
-Finally, let's consider the same composition but with an auto-propagated callback
-registered on the meta-estimator:
+The trace is similar to the first example, except that it is repeated for each fold. In
+particular, the `setup` and `teardown` hooks are called for every fit of the
+sub-estimator clone. Finally, consider the same composition with an auto-propagated
+callback registered on the meta-estimator:
 
 .. code-block:: python
 
     >>> estimator = MyEstimator(n_iter=10)
-    >>> MyEstimatorCV(estimator, cv=5).set_callbacks(MyAutoPropagatedCallback()).fit(X, y)
+    >>> MetaEstimatorCV(estimator, cv=5).set_callbacks(MyAutoPropagatedCallback()).fit(X, y)
     setup by MetaEstimatorCV for fit
     on_fit_task_begin by MetaEstimatorCV for fit
     on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
@@ -271,18 +270,18 @@ registered on the meta-estimator:
     on_fit_task_end by MaxIterEstimator for iteration 9
     on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
     ...  # folds 1 to 3
-    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
     on_fit_task_begin by MaxIterEstimator for iteration 0
     on_fit_task_end by MaxIterEstimator for iteration 0
     ...  # iterations 1 to 8
     on_fit_task_begin by MaxIterEstimator for iteration 9
     on_fit_task_end by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
     on_fit_task_end by MetaEstimatorCV for fit
     teardown by MetaEstimatorCV for fit
 
 This time, the callback hooks are also called for the tasks of the meta-estimator. Note
-that the setup and tear down are performed only once, by the meta-estimator.
+that the `setup` and `teardown` hooks are called only once, by the meta-estimator.
 
 Considerations
 --------------
@@ -297,23 +296,23 @@ Protocol extensions
 To keep the scope of this SLEP reasonable, it only considers callbacks called during
 fit but the API could be extended to other methods (e.g. `predict` or `transform`) or
 unbound functions (e.g. `cross_validate`) in the future.
-PR `#33404 <https://github.com/scikit-learn/scikit-learn/pull/33404>`__ for instance
+PR `#33404 <https://github.com/scikit-learn/scikit-learn/pull/33404>`__, for instance,
 proposes a new protocol for callback support in unbound functions.
 
 Task granularity
 ~~~~~~~~~~~~~~~~
 
 The smallest task granularity considered in this SLEP is tasks dealing with the full
-dataset. For instance the `on_fit_task_end` hook is called at the end of a loop
-iterating over the full dataset but not at the end of each step of such loop. A smaller
-granularity would not allow the same level of flexibility.
+dataset. For instance, the `on_fit_task_end` hook is called at the end of a loop
+iterating over the full dataset but not at the end of each step of such a loop. A
+smaller granularity would not allow the same level of flexibility.
 
 Performance
 ~~~~~~~~~~~
 
 It's inevitable that callbacks will have a performance cost, especially when called
-within cython nogil code. The most important thing is to make sure that when no
-callbacks are registered the performance is not affected (not acquiring the GIL for
+within Cython nogil code. The most important thing is to make sure that when no
+callbacks are registered, the performance is not affected (not acquiring the GIL for
 instance).
 
 Moreover, some information given to the hooks might be expensive to compute but is not
@@ -334,7 +333,7 @@ Non-callback-aware meta-estimators
 
 Callbacks can be registered on estimators that are passed to meta-estimators or unbound
 functions that do not support callbacks. In this case, callbacks should not break the
-workflow but might not provide full value and perform their work sub-optimally.
+workflow but might not provide full value and may perform suboptimally.
 
 Additional dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -348,7 +347,7 @@ Implementation
 
 An implementation of this SLEP is being developed in the `callbacks` feature branch.
 PR `#33322 <https://github.com/scikit-learn/scikit-learn/pull/33322>`__ keeps an updated
-diff againt the `main` branch. It currently contains the callback framework and the
+diff against the `main` branch. It currently contains the callback framework and the
 progress bar callback.
 
 Discussion

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -109,7 +109,8 @@ To add callback support to an estimator, scikit-learn provides three components:
 
   When a callback is evaluated for a given task, it receives the corresponding context
   which exposes attributes that provide information about the task being executed to be
-  used by the callback to adapt its behavior.
+  used by the callback to adapt its behavior. It also receives all the information that
+  the estimator is able to provide about the state of the fitting process at this task.
 
 - a `CallbackSupportMixin` class that the estimator should inherit from. This mixin
   exposes the following methods:
@@ -141,7 +142,9 @@ A typical implementation of callback support in an estimator would look like thi
             for i in range(self.n_iter):
                 subcontext = callback_ctx.subcontext(
                     task_name=f"iteration {i}", task_id=i
-                ).eval_on_fit_task_begin()
+                ).eval_on_fit_task_begin(
+                  data={"X_train": X, "y_train": y},
+                )
 
                 # <computation part of the estimator>
 
@@ -162,8 +165,8 @@ Callbacks must implement the following protocol:
 
     class FitCallback(Protocol):
         def setup(self, context): ...
-        def on_fit_task_begin(self, context, **kwargs): ...
-        def on_fit_task_end(self, context, **kwargs): ...
+        def on_fit_task_begin(self, context, *, data=None, metadata=None, fitted_estimator=None): ...
+        def on_fit_task_end(self, context, *, data=None, metadata=None, fitted_estimator=None): ...
         def teardown(self, context): ...
 
 The `setup` and `teardown` hooks are called at the beginning and end of `fit` and should
@@ -171,9 +174,9 @@ be used to setup and tear down the callback for the estimator. The `on_fit_task_
 and `on_fit_task_end` hooks are called at the beginning and end of each task performed
 during `fit`, including the root task.
 
-The extra keyword arguments received by the `on_fit_task_begin` and `on_fit_task_end`
-hooks contain all the information provided by the estimator about the state of the
-fitting process at this task. The possible keys are:
+The keyword arguments received by the `on_fit_task_begin` and `on_fit_task_end`
+hooks contain all the available information provided by the estimator about the state of
+the fitting process at this task:
 
 - "data": a dictionary containing the training and validation data.
 
@@ -183,8 +186,8 @@ fitting process at this task. The possible keys are:
 - "fitted_estimator": an estimator instance that is ready to predict, transform, etc.
   as if `fit` stopped at the end of this task.
 
-Note that estimators are not required to provide all of them and within a single
-estimator different tasks may provide different subsets of these keys.
+Note that some estimators may not be able to provide all of these information for every
+task.
 
 Auto-propagated callbacks must implement a small extension of this protocol:
 

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -103,7 +103,7 @@ To add callback support to an estimator, scikit-learn provides three components:
   beginning of `fit` and can be accessed as the `_callback_fix_ctx` of the estimator.
 
   It exposes three methods responsible for calling the hooks of the registered
-  callbacks: `evel_on_fit_begin`, `evel_on_fit_task_end` and `eval_on_fit_end`. In
+  callbacks: `eval_on_fit_begin`, `eval_on_fit_task_end` and `eval_on_fit_end`. In
   addition, it exposes a `propagate_callbacks` method to propagate callbacks from a
   meta-estimator to its inner estimators. Finally it exposes a `subcontext` method to
   create a `CallbackContext` instance for a subtask.

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -27,8 +27,8 @@ much it.
 
 Some use cases that have been requested many times on the scikit-learn issue tracker
 which are not possible to achieve with the current API are for instance progress bars,
-structured logging, metric monitoring, snapshots, etc. The callback API could also
-provide a generic and consistent API for early stopping, which is currently implemented
+structured logging, metric monitoring, snapshots, etc. A callback API could also provide
+a generic and consistent API for early stopping, which is currently implemented
 differently in only a few estimators. For such widely requested features, scikit-learn
 will provide builtin callbacks, but users would also be able to implement their own
 callbacks for less common use cases.
@@ -52,16 +52,16 @@ Using callbacks
 ~~~~~~~~~~~~~~~
 
 Callbacks are objects that can be registered to an estimator to be called at specific
-points during `fit`, gathering information about the training process. scikit-learn
+points during fit, gathering information about the training process. scikit-learn
 provides a set of builtin callbacks for common use cases, exposed in the
-`sklearn.callbacks` module.
+`sklearn.callback` module.
 
 Callbacks can be registered to an estimator using its `set_callbacks` method:
 
 .. code-block:: python
 
     from sklearn.linear_model import LogisticRegression
-    from sklearn.callbacks import ProgressBar
+    from sklearn.callback import ProgressBar
 
     callback = ProgressBar()
     clf = LogisticRegression()
@@ -79,7 +79,7 @@ registered on the outermost meta-estimator:
 
     from sklearn.linear_model import LogisticRegression
     from sklearn.model_selection import GridSearchCV
-    from sklearn.callbacks import EarlyStopping, ProgressBar
+    from sklearn.callback import EarlyStopping, ProgressBar
 
     clf = LogisticRegression().set_callbacks(EarlyStopping())
     gs = GridSearchCV(clf, param_grid)
@@ -91,12 +91,12 @@ Callback support in estimators
 
 To add callback support to an estimator, scikit-learn provides three components:
 
-- a `CallbackContext` class that is used to manage the callbacks during `fit`. Instances
-  of this class represent contexts of tasks being executed, where tasks are unit of work
-  defined by the estimator. There is one `CallbackContext` for each task. Tasks (and
-  therefore callback contexts) have a natural tree structure, where each task can be
-  decomposed into subtasks and so on, with the root task being the whole `fit` task.
-  Usually tasks correspond to iterations of loops during `fit` and nested loops
+- `CallbackContext`: a class that is used to manage the callbacks during fit.
+  Instances of this class represent contexts of tasks being executed, where tasks are
+  unit of work defined by the estimator. There is one `CallbackContext` for each task.
+  Tasks (and therefore callback contexts) have a natural tree structure, where each task
+  can be decomposed into subtasks and so on, with the root task being the whole fit
+  task. Usually tasks correspond to iterations of loops during fit and nested loops
   correspond to nested tasks, but in general a task can be any unit of work defined by
   the estimator.
 
@@ -113,16 +113,16 @@ To add callback support to an estimator, scikit-learn provides three components:
   used by the callback to adapt its behavior. It also receives all the information that
   the estimator is able to provide about the state of the fitting process at this task.
 
-- a `CallbackSupportMixin` class that the estimator should inherit from. This mixin
+- `CallbackSupportMixin`: a class that the estimator should inherit from. This mixin
   exposes the following methods:
 
   - `set_callbacks`, to register callbacks to the estimator.
   - `_init_callback_context`, to create the root callback context for the estimator
     and setup the callbacks for the estimator.
 
-- a `with_callbacks` decorator that the estimator should use to decorate the `fit`
-  method. It runs `fit` in a try-finally block to ensure that callbacks are properly
-  torn down no matter what happens during `fit`.
+- `with_callbacks`: a decorator that the estimator should use to decorate the fit
+  method. It runs fit in a try-finally block to ensure that callbacks are properly
+  torn down no matter what happens during fit.
 
 A typical implementation of callback support in an estimator would look like this:
 
@@ -157,7 +157,7 @@ The callback protocol
 ~~~~~~~~~~~~~~~~~~~~~
 
 Callbacks must implement the following
-`protocol<https://typing.python.org/en/latest/spec/protocol.html>`_:
+`protocol <https://typing.python.org/en/latest/spec/protocol.html>`__:
 
 .. code-block:: python
 
@@ -167,10 +167,10 @@ Callbacks must implement the following
         def on_fit_task_end(self, context, *, X=None, y=None, metadata=None, fitted_estimator=None): ...
         def teardown(self, context): ...
 
-The `setup` and `teardown` hooks are called at the beginning and end of `fit` and should
+The `setup` and `teardown` hooks are called at the beginning and end of fit and should
 be used to setup and tear down the callback for the estimator. The `on_fit_task_begin`
 and `on_fit_task_end` hooks are called at the beginning and end of each task performed
-during `fit`, including the root task.
+during fit, including the root task.
 
 The keyword arguments received by the `on_fit_task_begin` and `on_fit_task_end`
 hooks contain all the available information provided by the estimator about the state of
@@ -184,7 +184,7 @@ the fitting process at this task:
   weights, `X_val`, `y_val`, etc.
 
 - "fitted_estimator": an estimator instance that is ready to predict, transform, etc.
-  as if `fit` stopped at the end of this task.
+  as if fit stopped at the end of this task.
 
 Note that some estimators may not be able to provide values for all of these keys for
 every task.
@@ -200,6 +200,90 @@ Auto-propagated callbacks must implement a small extension of this protocol:
 `max_propagation_depth` defines the maximum nesting level of sub-estimators to propagate
 the callback to.
 
+Example traces of hook calls
+----------------------------
+
+This section provides examples of traces of callback hook calls in different scenarios.
+First let's consider the case where a callback is registered on an estimator that has a
+single level of iterations:
+
+.. code-block:: python
+
+    >>> estimator = MyEstimator(n_iter=10).set_callbacks(MyCallback())
+    >>> estimator.fit(X, y)
+    setup by MaxIterEstimator for fit
+    on_fit_task_begin by MaxIterEstimator for fit
+    on_fit_task_begin by MaxIterEstimator for iteration 0
+    on_fit_task_end by MaxIterEstimator for iteration 0
+    on_fit_task_begin by MaxIterEstimator for iteration 1
+    on_fit_task_end by MaxIterEstimator for iteration 1
+    ...  # iterations 2 to 8
+    on_fit_task_begin by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for fit
+    teardown by MaxIterEstimator for fit
+
+It doesn't matter whether `MyCallback` is auto-propagated or not since there is no
+sub-estimator to propagate it to in that case. Then, let's consider the case where the
+estimator from the previous example is used in a meta-estimator that fits clones of its
+sub-estimator for different cross-validation folds:
+
+.. code-block:: python
+
+    >>> estimator = MyEstimator(n_iter=10).set_callbacks(MyCallback())
+    >>> MetaEstimatorCV(estimator, cv=5).fit(X, y)
+    setup by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_begin by MaxIterEstimator for iteration 0
+    on_fit_task_end by MaxIterEstimator for iteration 0
+    ...  # iterations 1 to 8
+    on_fit_task_begin by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    teardown by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    ...  # folds 1 to 3
+    setup by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
+    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
+    on_fit_task_begin by MaxIterEstimator for iteration 0
+    on_fit_task_end by MaxIterEstimator for iteration 0
+    ...  # iterations 1 to 8
+    on_fit_task_begin by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
+    teardown by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
+
+The trace is similar to the first example except that it is repeated for each fold. In
+particular the setup and tear down are performed for each fit of the sub-estimator.
+Finally, let's consider the same composition but with an auto-propagated callback
+registered on the meta-estimator:
+
+.. code-block:: python
+
+    >>> estimator = MyEstimator(n_iter=10)
+    >>> MyEstimatorCV(estimator, cv=5).set_callbacks(MyAutoPropagatedCallback()).fit(X, y)
+    setup by MetaEstimatorCV for fit
+    on_fit_task_begin by MetaEstimatorCV for fit
+    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_begin by MaxIterEstimator for iteration 0
+    on_fit_task_end by MaxIterEstimator for iteration 0
+    ...  # iterations 1 to 8
+    on_fit_task_begin by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    ...  # folds 1 to 3
+    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_begin by MaxIterEstimator for iteration 0
+    on_fit_task_end by MaxIterEstimator for iteration 0
+    ...  # iterations 1 to 8
+    on_fit_task_begin by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for iteration 9
+    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+    on_fit_task_end by MetaEstimatorCV for fit
+    teardown by MetaEstimatorCV for fit
+
+This time, the callback hooks are also called for the tasks of the meta-estimator. Note
+that the setup and tear down are performed only once, by the meta-estimator.
+
 Considerations
 --------------
 
@@ -211,9 +295,9 @@ Protocol extensions
 ~~~~~~~~~~~~~~~~~~~
 
 To keep the scope of this SLEP reasonable, it only considers callbacks called during
-`fit` but the API could be extended to other methods (e.g. `predict` or `transform`) or
+fit but the API could be extended to other methods (e.g. `predict` or `transform`) or
 unbound functions (e.g. `cross_validate`) in the future.
-PR `#33404<https://github.com/scikit-learn/scikit-learn/pull/33404>`_ for instance
+PR `#33404 <https://github.com/scikit-learn/scikit-learn/pull/33404>`__ for instance
 proposes a new protocol for callback support in unbound functions.
 
 Task granularity
@@ -263,7 +347,7 @@ Implementation
 --------------
 
 An implementation of this SLEP is being developed in the `callbacks` feature branch.
-PR `#33322<https://github.com/scikit-learn/scikit-learn/pull/33322>`_ keeps an updated
+PR `#33322 <https://github.com/scikit-learn/scikit-learn/pull/33322>`__ keeps an updated
 diff againt the `main` branch. It currently contains the callback framework and the
 progress bar callback.
 
@@ -272,34 +356,34 @@ Discussion
 
 The goal of this SLEP is to provide a common solution for a wide range of use cases
 discussed in many long-standing issues and PRs, going back to issue
-`#78<https://github.com/scikit-learn/scikit-learn/issues/78>`_. Here are some related
-issues and PRs: `#4863<https://github.com/scikit-learn/scikit-learn/issues/4863>`_,
-`#7574<https://github.com/scikit-learn/scikit-learn/issues/7574>`_,
-`#8433<https://github.com/scikit-learn/scikit-learn/issues/8433>`_,
-`#8994<https://github.com/scikit-learn/scikit-learn/issues/8994>`_,
-`#9136<https://github.com/scikit-learn/scikit-learn/issues/9136>`_,
-`#10489<https://github.com/scikit-learn/scikit-learn/issues/10489>`_,
-`#10973<https://github.com/scikit-learn/scikit-learn/issues/10973>`_,
-`#12325<https://github.com/scikit-learn/scikit-learn/issues/12325>`_,
-`#14338<https://github.com/scikit-learn/scikit-learn/issues/14338>`_,
-`#14531<https://github.com/scikit-learn/scikit-learn/issues/14531>`_,
-`#16118<https://github.com/scikit-learn/scikit-learn/issues/16118>`_,
-`#18507<https://github.com/scikit-learn/scikit-learn/issues/18507>`_,
-`#18748<https://github.com/scikit-learn/scikit-learn/issues/18748>`_,
-`#18773<https://github.com/scikit-learn/scikit-learn/issues/18773>`_,
-`#20127<https://github.com/scikit-learn/scikit-learn/issues/20127>`_,
-`#20668<https://github.com/scikit-learn/scikit-learn/issues/20668>`_,
-`#23156<https://github.com/scikit-learn/scikit-learn/issues/23156>`_,
-`#24524<https://github.com/scikit-learn/scikit-learn/issues/24524>`_,
-`#25187<https://github.com/scikit-learn/scikit-learn/issues/25187>`_,
-`#26395<https://github.com/scikit-learn/scikit-learn/issues/26395>`_,
-`#26494<https://github.com/scikit-learn/scikit-learn/issues/26494>`_,
-`#26532<https://github.com/scikit-learn/scikit-learn/issues/26532>`_,
-`#1171<https://github.com/scikit-learn/scikit-learn/pull/1171>`_,
-`#3817<https://github.com/scikit-learn/scikit-learn/pull/3817>`_,
-`#8317<https://github.com/scikit-learn/scikit-learn/pull/8317>`_,
-`#16925<https://github.com/scikit-learn/scikit-learn/pull/16925>`_,
-`#22000<https://github.com/scikit-learn/scikit-learn/pull/22000>`_.
+`#78 <https://github.com/scikit-learn/scikit-learn/issues/78>`__. Here are some related
+issues and PRs: `#4863 <https://github.com/scikit-learn/scikit-learn/issues/4863>`__,
+`#7574 <https://github.com/scikit-learn/scikit-learn/issues/7574>`__,
+`#8433 <https://github.com/scikit-learn/scikit-learn/issues/8433>`__,
+`#8994 <https://github.com/scikit-learn/scikit-learn/issues/8994>`__,
+`#9136 <https://github.com/scikit-learn/scikit-learn/issues/9136>`__,
+`#10489 <https://github.com/scikit-learn/scikit-learn/issues/10489>`__,
+`#10973 <https://github.com/scikit-learn/scikit-learn/issues/10973>`__,
+`#12325 <https://github.com/scikit-learn/scikit-learn/issues/12325>`__,
+`#14338 <https://github.com/scikit-learn/scikit-learn/issues/14338>`__,
+`#14531 <https://github.com/scikit-learn/scikit-learn/issues/14531>`__,
+`#16118 <https://github.com/scikit-learn/scikit-learn/issues/16118>`__,
+`#18507 <https://github.com/scikit-learn/scikit-learn/issues/18507>`__,
+`#18748 <https://github.com/scikit-learn/scikit-learn/issues/18748>`__,
+`#18773 <https://github.com/scikit-learn/scikit-learn/issues/18773>`__,
+`#20127 <https://github.com/scikit-learn/scikit-learn/issues/20127>`__,
+`#20668 <https://github.com/scikit-learn/scikit-learn/issues/20668>`__,
+`#23156 <https://github.com/scikit-learn/scikit-learn/issues/23156>`__,
+`#24524 <https://github.com/scikit-learn/scikit-learn/issues/24524>`__,
+`#25187 <https://github.com/scikit-learn/scikit-learn/issues/25187>`__,
+`#26395 <https://github.com/scikit-learn/scikit-learn/issues/26395>`__,
+`#26494 <https://github.com/scikit-learn/scikit-learn/issues/26494>`__,
+`#26532 <https://github.com/scikit-learn/scikit-learn/issues/26532>`__,
+`#1171 <https://github.com/scikit-learn/scikit-learn/pull/1171>`__,
+`#3817 <https://github.com/scikit-learn/scikit-learn/pull/3817>`__,
+`#8317 <https://github.com/scikit-learn/scikit-learn/pull/8317>`__,
+`#16925 <https://github.com/scikit-learn/scikit-learn/pull/16925>`__,
+`#22000 <https://github.com/scikit-learn/scikit-learn/pull/22000>`__.
 
 References and Footnotes
 ------------------------

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -152,7 +152,7 @@ Performance
 ~~~~~~~~~~~
 
 It's inevitable that callbacks will have a performance cost, especially when called
-within cython nogil code. The most important thing is to make sure is that when no
+within cython nogil code. The most important thing is to make sure that when no
 callbacks are registered the performance is not affected (not acquiring the GIL for
 instance).
 

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -167,7 +167,8 @@ Callbacks must implement the following
         def on_fit_task_end(self, context, *, X=None, y=None, metadata=None, fitted_estimator=None): ...
         def teardown(self, context): ...
 
-The `setup` and `teardown` hooks are called at the beginning and end of fit and should
+The 4 protocol members are referred to as callback hooks in the rest of this SLEP. The
+`setup` and `teardown` hooks are called at the beginning and end of fit and should
 be used to set up and tear down the callback for the estimator. The `on_fit_task_begin`
 and `on_fit_task_end` hooks are called at the beginning and end of each task performed
 during fit, including the root task.
@@ -212,13 +213,11 @@ consider a callback registered on an estimator with a single level of iterations
     >>> estimator.fit(X, y)
     setup by MaxIterEstimator for fit
     on_fit_task_begin by MaxIterEstimator for fit
-    on_fit_task_begin by MaxIterEstimator for iteration 0
-    on_fit_task_end by MaxIterEstimator for iteration 0
-    on_fit_task_begin by MaxIterEstimator for iteration 1
-    on_fit_task_end by MaxIterEstimator for iteration 1
-    ...  # iterations 2 to 8
-    on_fit_task_begin by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for iteration 9
+        on_fit_task_begin by MaxIterEstimator for iteration 0
+        on_fit_task_end by MaxIterEstimator for iteration 0
+        ...  # iterations 1 to 8
+        on_fit_task_begin by MaxIterEstimator for iteration 9
+        on_fit_task_end by MaxIterEstimator for iteration 9
     on_fit_task_end by MaxIterEstimator for fit
     teardown by MaxIterEstimator for fit
 
@@ -233,21 +232,21 @@ that sub-estimator for different cross-validation folds:
     >>> MetaEstimatorCV(estimator, cv=5).fit(X, y)
     setup by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
     on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
-    on_fit_task_begin by MaxIterEstimator for iteration 0
-    on_fit_task_end by MaxIterEstimator for iteration 0
-    ...  # iterations 1 to 8
-    on_fit_task_begin by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for iteration 9
+        on_fit_task_begin by MaxIterEstimator for iteration 0
+        on_fit_task_end by MaxIterEstimator for iteration 0
+        ...  # iterations 1 to 8
+        on_fit_task_begin by MaxIterEstimator for iteration 9
+        on_fit_task_end by MaxIterEstimator for iteration 9
     on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
     teardown by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
     ...  # folds 1 to 3
     setup by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
     on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
-    on_fit_task_begin by MaxIterEstimator for iteration 0
-    on_fit_task_end by MaxIterEstimator for iteration 0
-    ...  # iterations 1 to 8
-    on_fit_task_begin by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for iteration 9
+        on_fit_task_begin by MaxIterEstimator for iteration 0
+        on_fit_task_end by MaxIterEstimator for iteration 0
+        ...  # iterations 1 to 8
+        on_fit_task_begin by MaxIterEstimator for iteration 9
+        on_fit_task_end by MaxIterEstimator for iteration 9
     on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
     teardown by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
 
@@ -262,21 +261,21 @@ callback registered on the meta-estimator:
     >>> MetaEstimatorCV(estimator, cv=5).set_callbacks(MyAutoPropagatedCallback()).fit(X, y)
     setup by MetaEstimatorCV for fit
     on_fit_task_begin by MetaEstimatorCV for fit
-    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
-    on_fit_task_begin by MaxIterEstimator for iteration 0
-    on_fit_task_end by MaxIterEstimator for iteration 0
-    ...  # iterations 1 to 8
-    on_fit_task_begin by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
-    ...  # folds 1 to 3
-    on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
-    on_fit_task_begin by MaxIterEstimator for iteration 0
-    on_fit_task_end by MaxIterEstimator for iteration 0
-    ...  # iterations 1 to 8
-    on_fit_task_begin by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for iteration 9
-    on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
+        on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+            on_fit_task_begin by MaxIterEstimator for iteration 0
+            on_fit_task_end by MaxIterEstimator for iteration 0
+            ...  # iterations 1 to 8
+            on_fit_task_begin by MaxIterEstimator for iteration 9
+            on_fit_task_end by MaxIterEstimator for iteration 9
+        on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 0)
+        ...  # folds 1 to 3
+        on_fit_task_begin by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
+            on_fit_task_begin by MaxIterEstimator for iteration 0
+            on_fit_task_end by MaxIterEstimator for iteration 0
+            ...  # iterations 1 to 8
+            on_fit_task_begin by MaxIterEstimator for iteration 9
+            on_fit_task_end by MaxIterEstimator for iteration 9
+        on_fit_task_end by MaxIterEstimator for fit (MetaEstimatorCV fold 4)
     on_fit_task_end by MetaEstimatorCV for fit
     teardown by MetaEstimatorCV for fit
 
@@ -299,13 +298,26 @@ unbound functions (e.g. `cross_validate`) in the future.
 PR `#33404 <https://github.com/scikit-learn/scikit-learn/pull/33404>`__, for instance,
 proposes a new protocol for callback support in unbound functions.
 
+The setup and teardown hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `setup` and `teardown` hooks are not absolutely necessary at the time of writing
+since `on_fit_task_begin` and `on_fit_task_end` are also called at the beginning and end
+of fit as well, so they could in principle be used to set up and tear down the callback.
+The main motivations for including them are:
+
+- in anticipation for future extensions of the protocol to other methods than fit;
+- to separate technical concerns of resource management from semantic concerns related
+  to reacting to specific events during fit.
+
 Task granularity
 ~~~~~~~~~~~~~~~~
 
 The smallest task granularity considered in this SLEP is tasks dealing with the full
 dataset. For instance, the `on_fit_task_end` hook is called at the end of a loop
 iterating over the full dataset but not at the end of each step of such a loop. A
-smaller granularity would not allow the same level of flexibility.
+smaller granularity would not allow the same level of flexibility and consistency across
+estimators.
 
 Performance
 ~~~~~~~~~~~

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -83,6 +83,26 @@ task performed during `fit`. Usually tasks correspond to iterations of loops dur
 `fit` and nested loops correspond to nested tasks, but in general a task can be any
 unit of work defined by the estimator.
 
+The `**kwargs` parameters receives all the information provided by the estimator about
+the state of the fitting process at this task. Possible keys are:
+
+- "data": a dictionary containing the training and validation data.
+
+- "stopping_criterion": a float. Usually iterations stop when
+  `stopping_criterion <= tol`.
+
+- "tol": a float. Tolerance for the stopping criterion.
+
+- "from_reconstruction_attributes": an estimator instance that is ready to predict,
+  transform, etc ... estimator as if the fit stopped at the end of this task.
+
+- "fit_state": a dictionary containing model specific quantities updated during fit.
+  This is not meant to be used by generic callbacks but by a callback designed for a
+  specific estimator instead.
+
+Note that all these keys are optional and that estimators are not required to provide
+all of them and within a single estimator different tasks may provide different keys.
+
 The `context` parameter is an instance of `CallbackContext`, which provides information
 about the current state of the computation, described in more details below.
 
@@ -107,6 +127,10 @@ To add callback support to an estimator, scikit-learn provides three components:
   addition, it exposes a `propagate_callbacks` method to propagate callbacks from a
   meta-estimator to its inner estimators. Finally it exposes a `subcontext` method to
   create a `CallbackContext` instance for a subtask.
+
+  The `CallbackContext` instance also exposes attributes that provide information about
+  the task being executed and its position in the hierarchy of tasks that callbacks can
+  use to adapt their behavior.
 
 A typical implementation of callback support in an estimator would look like this::
 

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -187,7 +187,8 @@ the fitting process at this task:
   as if `fit` stopped at the end of this task.
 
 Note that some estimators may not be able to provide all of these information for every
-task.
+task. That list is likely to be extended in the future so callbacks hooks should be
+tolerant to missing keys.
 
 Auto-propagated callbacks must implement a small extension of this protocol:
 

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -119,20 +119,20 @@ To add callback support to an estimator, scikit-learn provides three components:
   - `_init_callback_context`, to create the root callback context for the estimator
     and setup the callbacks for the estimator.
 
-- a `with_fit_callbacks` decorator that the estimator should use to decorate the
-  `fit` method. It runs `fit` in a try-finally block to ensure that callbacks are
-  properly torn down no matter what happens during `fit`.
+- a `with_callbacks` decorator that the estimator should use to decorate the `fit`
+  method. It runs `fit` in a try-finally block to ensure that callbacks are properly
+  torn down no matter what happens during `fit`.
 
 A typical implementation of callback support in an estimator would look like this:
 
 .. code-block:: python
 
     from sklearn.base import BaseEstimator
-    from sklearn.callback import CallbackSupportMixin, with_fit_callbacks
+    from sklearn.callback import CallbackSupportMixin, with_callbacks
 
     class MyEstimator(CallbackSupportMixin, BaseEstimator):
 
-        @with_fit_callbacks
+        @with_callbacks
         def fit(self, X, y):
             callback_ctx = self._init_callback_context(
                 task_name="fit", max_subtasks=self.n_iter

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -167,7 +167,7 @@ Callbacks must implement the following
         def on_fit_task_end(self, context, *, X=None, y=None, metadata=None, fitted_estimator=None): ...
         def teardown(self, context): ...
 
-The 4 protocol members are referred to as callback hooks in the rest of this SLEP. The
+The 4 protocol methods are referred to as callback hooks in the rest of this SLEP. The
 `setup` and `teardown` hooks are called at the beginning and end of fit and should
 be used to set up and tear down the callback for the estimator. The `on_fit_task_begin`
 and `on_fit_task_end` hooks are called at the beginning and end of each task performed

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -82,8 +82,9 @@ registered on the outermost meta-estimator:
     from sklearn.callbacks import EarlyStopping, ProgressBar
 
     clf = LogisticRegression().set_callbacks(EarlyStopping())
-    clf = GridSearchCV(clf, param_grid).set_callbacks(ProgressBar())
-    clf.fit(X, y)
+    gs = GridSearchCV(clf, param_grid)
+    gs.set_callbacks(ProgressBar(max_propagation_depth=1))
+    gs.fit(X, y)
 
 Callback support in estimators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -137,25 +138,26 @@ A typical implementation of callback support in an estimator would look like thi
             callback_ctx = self._init_callback_context(
                 task_name="fit", max_subtasks=self.n_iter
             )
-            callback_ctx.call_on_fit_task_begin()
+            callback_ctx.call_on_fit_task_begin(X=X, y=y)
 
             for i in range(self.n_iter):
-                subcontext = callback_ctx.subcontext(
+                callback_subctx = callback_ctx.subcontext(
                     task_name=f"iteration {i}", task_id=i
                 ).call_on_fit_task_begin(X=X, y=y)
 
                 # <computation part of the estimator>
 
-                subcontext.call_on_fit_task_end(X=X, y=y)
+                callback_subctx.call_on_fit_task_end(X=X, y=y)
 
-            callback_ctx.call_on_fit_task_end()
+            callback_ctx.call_on_fit_task_end(X=X, y=y)
 
             return self
 
 The callback protocol
 ~~~~~~~~~~~~~~~~~~~~~
 
-Callbacks must implement the following protocol:
+Callbacks must implement the following
+`protocol<https://typing.python.org/en/latest/spec/protocol.html>`_:
 
 .. code-block:: python
 


### PR DESCRIPTION
Proposal for an API for callbacks in scikit-learn.

The corresponding implementation is being worked in the ``callbacks`` feature branch.
The https://github.com/scikit-learn/scikit-learn/pull/33322 PR keeps an updated diff between ``callbacks`` and ``main`` and is meant to be seen as the implementation of this SLEP in scikit-learn.