### PR TITLE
SLEP024 Guideline for external posts on scikit-learn blog

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -25,6 +25,7 @@
     slep012/proposal
     slep017/proposal
     slep019/proposal
+    slep024/proposal
 
 .. toctree::
     :maxdepth: 1

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -40,12 +40,41 @@ write and review external contributions to the scikit-learn blog post.
 Guidelines
 ----------
 
-TODO
+In this section, we provide a set of guidelines to ease the discussions when reviewing
+external contributions to the scikit-learn blog post. It should help both the authors
+and the reviewers.
 
-Discussion
-----------
+Inclusion criteria
+^^^^^^^^^^^^^^^^^^
 
-TODO
+To accept an external contribution, the blog post should be related to the scikit-learn
+ecosystem. When it comes to presenting a compatible tool, the criteria are the
+following:
+
+- The tool should be compatible with scikit-learn.
+- The tool should be under an open-source license.
+- The tool should be actively maintained.
+- The tool should have a clear documentation.
+- The tool should be well tested.
+- The tool should not be a commercial product or serve advertisement for a company.
+
+Reproducibility requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the scikit-learn documentation, we ensure that our examples are reproducible and can
+be executed by using our continuous integration. When it comes to the scikit-learn blog
+post, it is not possible (or rather difficult) to have the same level of integration.
+
+However, we should ensure that the given examples or code snippets are reproducible by
+the readers. We therefore recommend the following:
+
+- Provide a link to a repository where the code or notebook is available that is used
+  as a baseline for the blog post.
+- The repository should contain a system to reproduce the environment (e.g.
+  `requirements.txt`, `environment.yml`, or `pixi.toml`).
+- If possible, a continuous integration should make sure that the code or notebook can
+  be executed. We understand that this step is sometimes impossible due to limit of
+  resources.
 
 References and Footnotes
 ------------------------

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -1,67 +1,51 @@
 .. _slep_024:
 
-==============================
-SLEP Template and Instructions
-==============================
+===========================================================================
+SLEP024: Guideline for external contributions to the scikit-learn blog post
+===========================================================================
 
-:Author: <list of authors' real names and optionally, email addresses>
-:Status: <Draft | Active | Accepted | Deferred | Rejected | Withdrawn |
-         Final | Superseded>
-:Type: <Standards Track | Process>
-:Created: <date created on, in yyyy-mm-dd format>
-:Resolution: <url> (required for Accepted | Rejected | Withdrawn)
+:Author: Guillaume Lemaitre, François Goupil
+:Status: Draft
+:Type: Standards Track
+:Created: 2024-08-09
 
 Abstract
 --------
 
-The abstract should be a short description of what the SLEP will achieve.
-
+This SLEP proposes some guidelines for writing and reviewing external contributions
+to the scikit-learn blog post.
 
 Detailed description
 --------------------
 
-This section describes the need for the SLEP. It should describe the
-existing problem that it is trying to solve and why this SLEP makes the
-situation better. It should include examples of how the new functionality
-would be used and perhaps some use cases.
+Scikit-learn has a blog post available at the following URL:
+https://blog.scikit-learn.org/. Since its origin, the blog post is used to relay
+information related to diverse subject such as sprints, interviews of contributors,
+collaborations, and technical content.
 
+When it comes to technical content, up to now, the content is only limited to the
+scikit-learn library. However, the scikit-learn community is going beyond the
+library itself and had developed compatible tools for years. As an example, the
+scikit-learn-contrib repository [2]_ is hosting a collection of tools which are not
+part of the main library but are still compatible with scikit-learn.
 
-Implementation
---------------
+This SLEP proposes to extend the scope of the technical content of the blog post to
+accept contributions in link with the scikit-learn ecosystem but not limited to the
+scikit-learn library itself. However, it is necessary to define some guidelines to
+manage expectations of contributors and readers.
 
-This section lists the major steps required to implement the SLEP.  Where
-possible, it should be noted where one step is dependent on another, and which
-steps may be optionally omitted.  Where it makes sense, each  step should
-include a link related pull requests as the implementation progresses.
+Here, we define the guidelines for external contributions that should be used to
+write and review external contributions to the scikit-learn blog post.
 
-Any pull requests or developmt branches containing work on this SLEP should
-be linked to from here.  (A SLEP does not need to be implemented in a single
-pull request if it makes sense to implement it in discrete phases).
+Guidelines
+----------
 
-
-Backward compatibility
-----------------------
-
-This section describes the ways in which the SLEP breaks backward
-compatibility.
-
-
-Alternatives
-------------
-
-If there were any alternative solutions to solving the same problem, they
-should be discussed here, along with a justification for the chosen
-approach.
-
+TODO
 
 Discussion
 ----------
 
-This section may just be a bullet list including links to any discussions
-regarding the SLEP:
-
-- This includes links to mailing list threads or relevant GitHub issues.
-
+TODO
 
 References and Footnotes
 ------------------------
@@ -70,8 +54,9 @@ References and Footnotes
    domain (see this SLEP as an example) or licensed under the `Open
    Publication License`_.
 
-.. _Open Publication License: https://www.opencontent.org/openpub/
+.. [2] `scikit-learn-contrib repository <https://github.com/scikit-learn-contrib>`__
 
+.. _Open Publication License: https://www.opencontent.org/openpub/
 
 Copyright
 ---------

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -1,0 +1,79 @@
+.. _slep_024:
+
+==============================
+SLEP Template and Instructions
+==============================
+
+:Author: <list of authors' real names and optionally, email addresses>
+:Status: <Draft | Active | Accepted | Deferred | Rejected | Withdrawn |
+         Final | Superseded>
+:Type: <Standards Track | Process>
+:Created: <date created on, in yyyy-mm-dd format>
+:Resolution: <url> (required for Accepted | Rejected | Withdrawn)
+
+Abstract
+--------
+
+The abstract should be a short description of what the SLEP will achieve.
+
+
+Detailed description
+--------------------
+
+This section describes the need for the SLEP. It should describe the
+existing problem that it is trying to solve and why this SLEP makes the
+situation better. It should include examples of how the new functionality
+would be used and perhaps some use cases.
+
+
+Implementation
+--------------
+
+This section lists the major steps required to implement the SLEP.  Where
+possible, it should be noted where one step is dependent on another, and which
+steps may be optionally omitted.  Where it makes sense, each  step should
+include a link related pull requests as the implementation progresses.
+
+Any pull requests or developmt branches containing work on this SLEP should
+be linked to from here.  (A SLEP does not need to be implemented in a single
+pull request if it makes sense to implement it in discrete phases).
+
+
+Backward compatibility
+----------------------
+
+This section describes the ways in which the SLEP breaks backward
+compatibility.
+
+
+Alternatives
+------------
+
+If there were any alternative solutions to solving the same problem, they
+should be discussed here, along with a justification for the chosen
+approach.
+
+
+Discussion
+----------
+
+This section may just be a bullet list including links to any discussions
+regarding the SLEP:
+
+- This includes links to mailing list threads or relevant GitHub issues.
+
+
+References and Footnotes
+------------------------
+
+.. [1] Each SLEP must either be explicitly labeled as placed in the public
+   domain (see this SLEP as an example) or licensed under the `Open
+   Publication License`_.
+
+.. _Open Publication License: https://www.opencontent.org/openpub/
+
+
+Copyright
+---------
+
+This document has been placed in the public domain. [1]_

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -56,14 +56,13 @@ and the scikit-learn ecosystem. However, we want the blog to be a place of quali
 content which encourages a thriving open-source ecosystem, and which to avoid it being
 flooded by advertising or special interests.
 
-Criteria for accepting a contributed blog post
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+General criteria for accepting a contributed blog post
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To accept an external contribution, the blog post should be related to the scikit-learn
 ecosystem.
 
-When it comes to presenting a compatible tool, the criteria are the
-following:
+When it comes to presenting **a compatible tool**, the guidelines are the following:
 
 - The tool should be compatible with scikit-learn.
 - The tools used in the blog need to be under an OSI approved or similar license.
@@ -71,7 +70,7 @@ following:
 - The tool should have a clear documentation.
 - The tool should be well tested.
 
-More generally, even for content not presenting a tool, the following criteria apply:
+More generally, even for content not presenting a tool, the following guidelines apply:
 
 - The content should adhere to our code of conduct standards.
 - The content should not be advertisement for a commercial endeavor (see below)

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -15,6 +15,11 @@ Abstract
 This SLEP proposes some guidelines for writing and reviewing external contributions
 to the scikit-learn blog post.
 
+The motivation is this SLEP is to increasingly open up the scikit-learn blog for
+external contribution. Editorial guidelines are difficult to build. The goal of this
+SLEP is not to give all the details (they can be refined on the blog website), but the
+general guiding lines.
+
 Detailed description
 --------------------
 
@@ -51,11 +56,13 @@ and the scikit-learn ecosystem. However, we want the blog to be a place of quali
 content which encourages a thriving open-source ecosystem, and which to avoid it being
 flooded by advertising or special interests.
 
-Inclusion criteria
-^^^^^^^^^^^^^^^^^^
+Criteria for accepting a contributed blog post
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To accept an external contribution, the blog post should be related to the scikit-learn
-ecosystem. When it comes to presenting a compatible tool, the criteria are the
+ecosystem.
+
+When it comes to presenting a compatible tool, the criteria are the
 following:
 
 - The tool should be compatible with scikit-learn.
@@ -63,6 +70,9 @@ following:
 - The tool should be actively maintained.
 - The tool should have a clear documentation.
 - The tool should be well tested.
+
+More generally, even for content not presenting a tool, the following criteria apply:
+
 - The content should adhere to our code of conduct standards.
 - The content should not be advertisement for a commercial endeavor (see below)
 - Claims should, as much as possible, backed by authoritative sources or reproducible

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -83,7 +83,7 @@ criteria.
 Commercial links
 ^^^^^^^^^^^^^^^^
 
-A blog article  should not be on a commercial product or serve advertisement for a
+A blog article should not be on a commercial product or serve advertisement for a
 company. Likewise the content of the post should be limited to the tool at hand, rather
 than using the tool to advertise a commercial ecosystem / tool.
 

--- a/slep024/proposal.rst
+++ b/slep024/proposal.rst
@@ -4,7 +4,7 @@
 SLEP024: Guideline for external contributions to the scikit-learn blog post
 ===========================================================================
 
-:Author: Guillaume Lemaitre, François Goupil
+:Author: Guillaume Lemaitre, François Goupil, Gaël Varoquaux
 :Status: Draft
 :Type: Standards Track
 :Created: 2024-08-09
@@ -21,12 +21,13 @@ Detailed description
 Scikit-learn has a blog post available at the following URL:
 https://blog.scikit-learn.org/. Since its origin, the blog post is used to relay
 information related to diverse subject such as sprints, interviews of contributors,
-collaborations, and technical content.
+collaborations, and technical content. Hosting quality content on the scikit-learn blog
+increases the visibility of scikit-learn and we should foster it.
 
-When it comes to technical content, up to now, the content is only limited to the
-scikit-learn library. However, the scikit-learn community is going beyond the
+Technical content limited to the scikit-learn library is natural on the blog.
+However, the scikit-learn community goes beyond the
 library itself and had developed compatible tools for years. As an example, the
-scikit-learn-contrib repository [2]_ is hosting a collection of tools which are not
+scikit-learn-contrib repository [2]_ hosts a collection of tools which are not
 part of the main library but are still compatible with scikit-learn.
 
 This SLEP proposes to extend the scope of the technical content of the blog post to
@@ -34,7 +35,7 @@ accept contributions in link with the scikit-learn ecosystem but not limited to 
 scikit-learn library itself. However, it is necessary to define some guidelines to
 manage expectations of contributors and readers.
 
-Here, we define the guidelines for external contributions that should be used to
+Here, we define the **guidelines for external contributions** that should be used to
 write and review external contributions to the scikit-learn blog post.
 
 Guidelines
@@ -44,6 +45,12 @@ In this section, we provide a set of guidelines to ease the discussions when rev
 external contributions to the scikit-learn blog post. It should help both the authors
 and the reviewers.
 
+**Philosophy**: the scikit-learn blog lives because people take the effort of writing
+posts. These contributions are welcomed to produce quality content on machine learning
+and the scikit-learn ecosystem. However, we want the blog to be a place of quality
+content which encourages a thriving open-source ecosystem, and which to avoid it being
+flooded by advertising or special interests.
+
 Inclusion criteria
 ^^^^^^^^^^^^^^^^^^
 
@@ -52,11 +59,29 @@ ecosystem. When it comes to presenting a compatible tool, the criteria are the
 following:
 
 - The tool should be compatible with scikit-learn.
-- The tool should be under an open-source license.
+- The tools used in the blog need to be under an OSI approved or similar license.
 - The tool should be actively maintained.
 - The tool should have a clear documentation.
 - The tool should be well tested.
-- The tool should not be a commercial product or serve advertisement for a company.
+- The content should adhere to our code of conduct standards.
+- The content should not be advertisement for a commercial endeavor (see below)
+- Claims should, as much as possible, backed by authoritative sources or reproducible
+  code (see below)
+
+Note that there will be an element of human judgment in applying these inclusion
+criteria.
+
+Commercial links
+^^^^^^^^^^^^^^^^
+
+A blog article  should not be on a commercial product or serve advertisement for a
+company. Likewise the content of the post should be limited to the tool at hand, rather
+than using the tool to advertise a commercial ecosystem / tool.
+
+However, organizations that financially sponsor the project by hiring (near-)full-time
+core contributors can use the scikit-learn blog to advertise open-source resources
+related to scikit-learn in their own name as long as the relationship to the
+scikit-learn project is made explicit in the blog post.
 
 Reproducibility requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This SLEP intends to have a discussion to define a clear guideline allowing to accept external contribution in the scikit-learn blog post.