### PR TITLE
VOTE SLEP 23: Callback API

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -17,12 +17,11 @@
     slep017/proposal
     slep018/proposal
     slep020/proposal
+    slep023/proposal
 
 .. toctree::
     :maxdepth: 1
     :caption: Under review
-
-    slep023/proposal
 
 .. toctree::
     :maxdepth: 1

--- a/slep023/proposal.rst
+++ b/slep023/proposal.rst
@@ -5,9 +5,10 @@ SLEP023: Callback API
 =====================
 
 :Author: Jérémie du Boisberranger
-:Status: Draft
+:Status: Accepted
 :Type: Standards Track
 :Created: 2024-03-01
+:Resolution: https://github.com/scikit-learn/enhancement_proposals/pull/103
 
 Abstract
 --------


### PR DESCRIPTION
This PR collects the votes for [SLEP023: Callback API](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep023/proposal.html).

This SLEP is being implemented in the `callbacks` feature branch. https://github.com/scikit-learn/scikit-learn/pull/33322 keeps and updated diff against `main`. It currently contains the framework and a callback for ProgressBars.
On top of that, there's ongoing work to:
- Add a callback to monitor a score during fit (https://github.com/scikit-learn/scikit-learn/pull/33407). It's compatible with the already merged api but we still trying to figure out the best format for the logged score values.
- Add developer documentation to implement callback support in scikit-learn and third party estimators (https://github.com/scikit-learn/scikit-learn/pull/33423). It's still wip and we'll keep improving it in the coming weeks. Documentation for end users will also arrive soon.
- Add callback support in SearchCV classes (https://github.com/scikit-learn/scikit-learn/pull/33533). We'll also draft PRs to add support in Pipeline and a couple of key estimators in the coming weeks.
- Keep improving the inspection of the callback framework (https://github.com/scikit-learn/scikit-learn/pull/33591). It will be useful not only for testing and debugging but for end users as well.

According to our [governance model](https://scikit-learn.org/stable/governance.html#decision-making-process), the vote will be open for a month (untill April 20), and the motion is accepted if 2/3 of the cast votes are in favor.

@scikit-learn/core-devs